### PR TITLE
docs: place fences around rust-like doc text

### DIFF
--- a/sonata-codec-mp3/src/layer3/stereo.rs
+++ b/sonata-codec-mp3/src/layer3/stereo.rs
@@ -112,8 +112,11 @@ lazy_static! {
 /// As per ISO/IEC 11172-3, to reconstruct the left and right channels, the following calculation
 /// is performed:
 ///
+/// ```text
 ///      l[i] = (m[i] + s[i]) / sqrt(2)
 ///      r[i] = (m[i] - s[i]) / sqrt(2)
+/// ```
+///
 /// where:
 ///      l[i], and r[i] are the left and right channels, respectively.
 ///      m[i], and s[i] are the mid and side channels, respectively.
@@ -141,8 +144,10 @@ fn process_mid_side(mid: &mut [f32], side: &mut [f32]) {
 /// As per ISO/IEC 11172-3, the following calculation may be performed to decode the intensity
 /// stereo coded signal into left and right channels.
 ///
+/// ```text
 ///      l[i] = ch0[i] * k_l
 ///      r[i] = ch0[i] * l_r
+/// ```
 ///
 /// where:
 ///      l[i], and r[i] are the left and right channels, respectively.
@@ -181,8 +186,10 @@ fn process_intensity_mpeg1(is_pos: usize, mid_side: bool, ch0: &mut [f32], ch1: 
 /// As per ISO/IEC 13818-3, the following calculation may be performed to decode the intensity
 /// stereo coded signal into left and right channels.
 ///
+/// ```text
 ///      l[i] = ch0[i] * k_l
 ///      r[i] = ch0[i] * l_r
+/// ```text
 ///
 /// where:
 ///      l[i], and r[i] are the left and right channels, respectively.

--- a/sonata-core/src/conv.rs
+++ b/sonata-core/src/conv.rs
@@ -144,8 +144,8 @@ pub mod dither {
     add_noise_impl!(u32, self, s, {
         u32::from_sample(f64::from_sample(s) + f64::from_sample(self.0))
     });
-    add_noise_impl!(f32, self, s, { s + f32::from_sample(self.0) });
-    add_noise_impl!(f64, self, s, { s + f64::from_sample(self.0) });
+    add_noise_impl!(f32, self, s,  s + f32::from_sample(self.0) );
+    add_noise_impl!(f64, self, s,  s + f64::from_sample(self.0) );
 
     /// `Dither` is a trait for implementing dithering algorithms.
     pub trait Dither<F: Sample, T: Sample> {


### PR DESCRIPTION
Fix compilation by adding code fences around rust-like documentation text.