### PR TITLE
Change AudioPlanes::planes() to &self instead of &mut self

### DIFF
--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -249,7 +249,7 @@ impl<'a, S : Sample> AudioPlanes<'a, S> {
     }
 
     /// Gets all the audio planes.
-    pub fn planes(&mut self) -> &[&'a [S]] {
+    pub fn planes(&self) -> &[&'a [S]] {
         &self.planes
     }
 }


### PR DESCRIPTION
Pretty sure it doesn't need &mut.