### PR TITLE
Add GitHub actions workflow for testing builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+# Uncomment to check formatting:
+#    - name: Check Formatting
+#      uses: actions-rs/cargo@v1
+#      with:
+#        command: fmt
+#        args: -- --check
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --all --all-features --exclude symphonia-play
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --all-features --exclude symphonia-play


### PR DESCRIPTION
This will build and test pull requests and the master branch when pushed to.

Note that `rustfmt` check is included, but since codebase is not formatted it is currently commented out. It would however be nice to format the code and include it, since manual formatting is a bit tedious and arbitrary.

You can see an example build of this here: https://github.com/udoprog/Symphonia/actions/runs/674345665

Fixes #11