### PR TITLE
Add support for a few more atoms and components required for m4a files

### DIFF
--- a/symphonia-format-isomp4/src/atoms/ftyp.rs
+++ b/symphonia-format-isomp4/src/atoms/ftyp.rs
@@ -11,8 +11,6 @@ use symphonia_core::io::ByteStream;
 use crate::atoms::{Atom, AtomHeader};
 use crate::fourcc::FourCc;
 
-use log::warn;
-
 /// File type atom.
 #[derive(Debug)]
 pub struct FtypAtom {
@@ -30,10 +28,7 @@ impl Atom for FtypAtom {
         }
     
         // Major
-        let major = match FourCc::from_bytes(reader.read_quad_bytes()?) {
-            Some(fourcc) => fourcc,
-            _            => return decode_error("illegal fourcc"),
-        };
+        let major = FourCc::new(reader.read_quad_bytes()?);
 
         // Minor
         let minor = reader.read_quad_bytes()?;
@@ -45,13 +40,7 @@ impl Atom for FtypAtom {
 
         for _ in 0..n_brands {
             let brand = reader.read_quad_bytes()?;
-
-            if let Some(fourcc) = FourCc::from_bytes(brand) {
-                compatible.push(fourcc);
-            }
-            else {
-                warn!("ignoring illegal fourcc for compatible brand");
-            }
+            compatible.push(FourCc::new(brand));
         }
 
         Ok(FtypAtom { header, major, minor, compatible })

--- a/symphonia-format-isomp4/src/atoms/hdlr.rs
+++ b/symphonia-format-isomp4/src/atoms/hdlr.rs
@@ -21,6 +21,8 @@ pub enum TrackType {
     Subtitle,
     /// Metadata track.
     Metadata,
+    /// Text track.
+    Text,
 }
 
 /// Handler atom.
@@ -50,7 +52,10 @@ impl Atom for HdlrAtom {
             b"soun" => TrackType::Sound,
             b"meta" => TrackType::Metadata,
             b"subt" => TrackType::Subtitle,
-            _       => return decode_error("illegal track type"),
+            b"text" => TrackType::Text,
+            _ => {
+                return decode_error("illegal track type")
+            }
         };
 
         // Ignore component manufacturer, flags, and flags mask.

--- a/symphonia-format-isomp4/src/fourcc.rs
+++ b/symphonia-format-isomp4/src/fourcc.rs
@@ -5,26 +5,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::fmt;
+
 /// Four character codes for typical Ftyps (reference: http://ftyps.com/).
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Clone, Copy)]
+#[repr(transparent)]
 pub struct FourCc {
-    pub val: String,
+    val: [u8; 4],
 }
 
 impl FourCc {
-
-    pub fn from_bytes(val: [u8; 4]) -> Option<Self> {
-        let mut fourcc = FourCc { val: String::new() };
-
-        for &byte in val.iter() {
-            // The characters of a FourCC must be ASCII printable characters.
-            if byte < 0x20 || byte > 0x7e {
-                return None;
-            }
-            fourcc.val.push(char::from(byte));
-        }
-
-        Some(fourcc)
+    /// Construct a new FourCC code from the given byte array.
+    pub fn new(val: [u8; 4]) -> Self {
+        Self { val }
     }
+}
 
+impl fmt::Debug for FourCc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        String::from_utf8_lossy(&self.val).fmt(f)
+    }
 }


### PR DESCRIPTION
This removes the requirements that FourCC codes have to be readable ASCII and adds another track type `b"text"` to hdlr.

I encountered an `.m4a` file that reported its major brand as b"m4a\0" which also included this track type. I think It's legal according to the spec, but I'd have to double check this.