### PR TITLE
Fix #24: Require MediaSource to be Send

### DIFF
--- a/symphonia-core/src/io/mod.rs
+++ b/symphonia-core/src/io/mod.rs
@@ -25,7 +25,7 @@ pub use scoped_stream::ScopedStream;
 
 /// A `MediaSource` is a composite trait of `std::io::Read` and `std::io::Seek`. Despite requiring
 /// the `Seek` trait, seeking is an optional capability that can be queried at runtime.
-pub trait MediaSource: io::Read + io::Seek {
+pub trait MediaSource: io::Read + io::Seek + Send {
     /// Returns if the source is seekable. This may be an expensive operation.
     fn is_seekable(&self) -> bool;
 
@@ -60,7 +60,7 @@ impl MediaSource for std::fs::File {
     }
 }
 
-impl<T: std::convert::AsRef<[u8]>> MediaSource for io::Cursor<T> {
+impl<T: std::convert::AsRef<[u8]> + Send> MediaSource for io::Cursor<T> {
     /// Always returns true since a `io::Cursor<u8>` is always seekable.
     fn is_seekable(&self) -> bool {
         true
@@ -104,7 +104,7 @@ impl<R: io::Read> ReadOnlySource<R> {
     }
 }
 
-impl<R: io::Read> MediaSource for ReadOnlySource<R> {
+impl<R: io::Read + Send> MediaSource for ReadOnlySource<R> {
     fn is_seekable(&self) -> bool {
         false
     }


### PR DESCRIPTION
This should allow `MediaSource` based types like `MediaSourceStream` to be Send. Otherwise, as it stands, these streams cannot be sent from one thread to another. With most audio streams, it should be a safe assumption that they can be moved from thread to thread, but likely not `Sync`.