### PR TITLE
Fix UnexpectedEof when using Read::read_to_end on MediaSourceStream

### DIFF
--- a/symphonia-core/src/io/media_source_stream.rs
+++ b/symphonia-core/src/io/media_source_stream.rs
@@ -383,7 +383,13 @@ impl ByteStream for MediaSourceStream {
     #[inline(always)]
     fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // Implemented via io::Read trait.
-        self.read(buf)
+        let read = self.read(buf)?;
+        if read == 0 && buf.len() > 0 {
+            Err(io::Error::new(io::ErrorKind::UnexpectedEof, END_OF_STREAM_ERROR_STR))
+        }
+        else {
+            Ok(read)
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
Calling `Read::read_to_end` on a `MediaSourceStream` returns an UnexpectedEof instead of properly returning the read values. This is  particularly useful in unit tests. This PR fixes this issue.

Added unit tests to ensure this remains fixed.