### PR TITLE
Add into_inner function to allow access to the stream

### DIFF
--- a/symphonia-bundle-flac/src/demuxer.rs
+++ b/symphonia-bundle-flac/src/demuxer.rs
@@ -251,6 +251,10 @@ impl FormatReader for FlacReader {
         }
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.reader
+    }
+
 }
 
 /// Reads a StreamInfo block and populates the reader with stream information.

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -192,4 +192,8 @@ impl FormatReader for Mp3Reader {
         Ok(SeekTo::TimeStamp { ts: self.next_packet_ts, stream: 0 })
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.reader
+    }
+
 }

--- a/symphonia-codec-aac/src/adts.rs
+++ b/symphonia-codec-aac/src/adts.rs
@@ -167,4 +167,8 @@ impl FormatReader for AdtsReader {
         unimplemented!();
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.reader
+    }
+
 }

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -156,6 +156,8 @@ pub trait FormatReader {
 
     /// Get the next packet from the container.
     fn next_packet(&mut self) -> Result<Packet>;
+
+    fn into_inner(self: Box<Self>) -> MediaSourceStream;
 }
 
 /// A `Packet` contains a discrete amount of encoded data for a single codec bitstream. The exact

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -157,6 +157,7 @@ pub trait FormatReader {
     /// Get the next packet from the container.
     fn next_packet(&mut self) -> Result<Packet>;
 
+    /// Destroys the `FormatReader` and returns the underlying stream
     fn into_inner(self: Box<Self>) -> MediaSourceStream;
 }
 

--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -483,4 +483,8 @@ impl FormatReader for IsoMp4Reader {
         unsupported_error("seeking unsupported")
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.iter.into_inner()
+    }
+
 }

--- a/symphonia-format-ogg/src/demuxer.rs
+++ b/symphonia-format-ogg/src/demuxer.rs
@@ -160,5 +160,9 @@ impl FormatReader for OggReader {
         unsupported_error("ogg seeking unsupported")
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.reader
+    }
+
 }
 

--- a/symphonia-format-wav/src/lib.rs
+++ b/symphonia-format-wav/src/lib.rs
@@ -228,6 +228,10 @@ impl FormatReader for WavReader {
         Ok(to)
     }
 
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.reader
+    }
+
 }
 
 fn read_info_chunk(source: &mut MediaSourceStream, len: u32) -> Result<Metadata> {


### PR DESCRIPTION
This adds a way to destroy the `FormatReader` and get access to the underlying stream. This is useful if you need to directly manipulate the stream and then restart playback. I'm working on integrating Symphonia with Rodio and this technique is used [here](https://github.com/RustAudio/rodio/blob/master/src/decoder/mod.rs#L262) to loop an audio source.