### PR TITLE
Make MetadataQueue's modification methods consistent

### DIFF
--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -11,7 +11,7 @@ use symphonia_core::codecs::{CodecParameters, CODEC_TYPE_MP3};
 use symphonia_core::errors::{Result, SeekErrorKind, seek_error};
 use symphonia_core::formats::prelude::*;
 use symphonia_core::io::*;
-use symphonia_core::meta::MetadataQueue;
+use symphonia_core::meta::{Metadata, MetadataLog};
 use symphonia_core::probe::{Descriptor, Instantiate, QueryDescriptor};
 
 use std::io::{Seek, SeekFrom};
@@ -27,7 +27,7 @@ pub struct Mp3Reader {
     reader: MediaSourceStream,
     tracks: Vec<Track>,
     cues: Vec<Cue>,
-    metadata: MetadataQueue,
+    metadata: MetadataLog,
     first_frame_pos: u64,
     next_packet_ts: u64,
 }
@@ -104,8 +104,8 @@ impl FormatReader for Mp3Reader {
         Ok(Packet::new_from_boxed_slice(0, ts, duration, packet_buf.into_boxed_slice()))
     }
 
-    fn metadata(&self) -> &MetadataQueue {
-        &self.metadata
+    fn metadata(&mut self) -> Metadata<'_> {
+        self.metadata.metadata()
     }
 
     fn cues(&self) -> &[Cue] {

--- a/symphonia-codec-aac/src/adts.rs
+++ b/symphonia-codec-aac/src/adts.rs
@@ -13,7 +13,7 @@ use symphonia_core::codecs::{CodecParameters, CODEC_TYPE_AAC};
 use symphonia_core::errors::{Result, SeekErrorKind, decode_error, seek_error};
 use symphonia_core::formats::prelude::*;
 use symphonia_core::io::*;
-use symphonia_core::meta::MetadataQueue;
+use symphonia_core::meta::{Metadata, MetadataLog};
 use symphonia_core::probe::{Descriptor, Instantiate, QueryDescriptor};
 
 use std::io::{Seek, SeekFrom};
@@ -31,7 +31,7 @@ pub struct AdtsReader {
     reader: MediaSourceStream,
     tracks: Vec<Track>,
     cues: Vec<Cue>,
-    metadata: MetadataQueue,
+    metadata: MetadataLog,
     first_frame_pos: u64,
     next_packet_ts: u64,
 }
@@ -174,8 +174,8 @@ impl FormatReader for AdtsReader {
         ))
     }
 
-    fn metadata(&self) -> &MetadataQueue {
-        &self.metadata
+    fn metadata(&mut self) -> Metadata<'_> {
+        self.metadata.metadata()
     }
 
     fn cues(&self) -> &[Cue] {

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -11,7 +11,7 @@
 use crate::codecs::CodecParameters;
 use crate::errors::Result;
 use crate::io::{BufStream, MediaSourceStream};
-use crate::meta::{MetadataQueue, Tag};
+use crate::meta::{Metadata, Tag};
 use crate::units::{Time, TimeStamp};
 
 pub mod prelude {
@@ -175,8 +175,8 @@ pub trait FormatReader: Send {
     /// Gets a list of all `Cue`s.
     fn cues(&self) -> &[Cue];
 
-    /// Gets the metadata revision queue.
-    fn metadata(&self) -> &MetadataQueue;
+    /// Gets the metadata revision log.
+    fn metadata(&mut self) -> Metadata<'_>;
 
     /// Seek, as precisely as possible depending on the mode, to the `Time` or track `TimeStamp`
     /// requested. Returns the requested and actual `TimeStamps` seeked to, as well as the `Track`.

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -11,7 +11,7 @@
 use crate::errors::{Result, unsupported_error};
 use crate::formats::{FormatOptions, FormatReader};
 use crate::io::{ByteStream, MediaSourceStream};
-use crate::meta::{MetadataReader, MetadataOptions, MetadataLog};
+use crate::meta::{MetadataReader, MetadataOptions, MetadataLog, Metadata};
 
 use log::{error, info};
 
@@ -156,17 +156,36 @@ impl Hint {
     }
 }
 
+/// Metadata that came from the `metadata` field of [`ProbeResult`].
+pub struct ProbedMetadata {
+    metadata: Option<MetadataLog>,
+}
+
+impl ProbedMetadata {
+    /// Returns the metadata that was found during probing.
+    ///
+    /// If any additional metadata was present outside of the container, this is
+    /// `Some` and the log will have at least one item in it.
+    pub fn get(&mut self) -> Option<Metadata<'_>> {
+        self.metadata.as_mut().map(|m| m.metadata())
+    }
+
+    /// Returns the inner metadata log, if it was present.
+    pub fn into_inner(self) -> Option<MetadataLog> {
+        self.metadata
+    }
+}
+
 /// `ProbeResult` contains the result of a format probe operation.
 pub struct ProbeResult {
     /// An instance of a `FormatReader` for the probed format
     pub format: Box<dyn FormatReader>,
     /// A log of `Metadata` revisions read during the probe operation before the instantiation of
-    /// the `FormatReader`. If any additional metadata was present outside of the container, this is
-    /// `Some` and the log will have at least one item in it.
+    /// the `FormatReader`.
     ///
     /// Metadata that was part of the container format itself can be read by calling `.metadata()`
     /// on `format`.
-    pub metadata: Option<MetadataLog>,
+    pub metadata: ProbedMetadata,
 }
 
 /// `Probe` scans a `MediaSourceStream` for metadata and container formats, and provides an
@@ -314,7 +333,7 @@ impl Probe {
                         None
                     };
 
-                    return Ok(ProbeResult { format, metadata });
+                    return Ok(ProbeResult { format, metadata: ProbedMetadata { metadata } });
                 }
                 // If metadata was found, instantiate the metadata reader, read the metadata, and
                 // push it onto the metadata log.

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -8,7 +8,7 @@
 use symphonia_core::errors::{Result, decode_error};
 use symphonia_core::io::{ByteStream, BufStream};
 use symphonia_core::util::bits;
-use symphonia_core::meta::{Metadata, MetadataBuilder, StandardTagKey, StandardVisualKey, Tag};
+use symphonia_core::meta::{MetadataRevision, MetadataBuilder, StandardTagKey, StandardVisualKey, Tag};
 use symphonia_core::meta::{Value, Visual};
 use symphonia_metadata::{id3v1, itunes};
 
@@ -634,7 +634,7 @@ pub struct IlstAtom {
     /// Atom header.
     header: AtomHeader,
     /// Metadata revision.
-    pub metadata: Metadata,
+    pub metadata: MetadataRevision,
 }
 
 impl Atom for IlstAtom {

--- a/symphonia-format-isomp4/src/atoms/meta.rs
+++ b/symphonia-format-isomp4/src/atoms/meta.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 use symphonia_core::errors::Result;
 use symphonia_core::io::ByteStream;
-use symphonia_core::meta::{Metadata, MetadataQueue};
+use symphonia_core::meta::{MetadataRevision, MetadataLog};
 
 use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, IlstAtom};
 
@@ -18,7 +18,7 @@ pub struct MetaAtom {
     /// Atom header.
     header: AtomHeader,
     /// Metadata revision.
-    pub metadata: Metadata,
+    pub metadata: MetadataRevision,
 }
 
 impl Debug for MetaAtom {
@@ -28,9 +28,9 @@ impl Debug for MetaAtom {
 }
 
 impl MetaAtom {
-    /// Consumes the metadata, and pushes it onto provided `MetadataQueue`.
-    pub fn take_metadata(self, queue: &mut MetadataQueue) {
-        queue.push(self.metadata);
+    /// Consumes the metadata, and pushes it onto provided `MetadataLog`.
+    pub fn take_metadata(self, log: &mut MetadataLog) {
+        log.push(self.metadata)
     }
 }
 

--- a/symphonia-format-isomp4/src/atoms/moov.rs
+++ b/symphonia-format-isomp4/src/atoms/moov.rs
@@ -7,7 +7,7 @@
 
 use symphonia_core::errors::{Result, decode_error};
 use symphonia_core::io::ByteStream;
-use symphonia_core::meta::MetadataQueue;
+use symphonia_core::meta::MetadataLog;
 
 use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, MvexAtom, MvhdAtom, TrakAtom, UdtaAtom};
 
@@ -29,10 +29,10 @@ pub struct MoovAtom {
 }
 
 impl MoovAtom {
-    /// Consume any metadata, and pushes it onto provided `MetadataQueue`.
-    pub fn take_metadata(&mut self, queue: &mut MetadataQueue) {
+    /// Consume any metadata, and pushes it onto provided `MetadataLog`.
+    pub fn take_metadata(&mut self, log: &mut MetadataLog) {
         if let Some(udta) = self.udta.as_mut() {
-            udta.take_metadata(queue);
+            udta.take_metadata(log)
         }
     }
 

--- a/symphonia-format-isomp4/src/atoms/udta.rs
+++ b/symphonia-format-isomp4/src/atoms/udta.rs
@@ -7,7 +7,7 @@
 
 use symphonia_core::errors::Result;
 use symphonia_core::io::ByteStream;
-use symphonia_core::meta::MetadataQueue;
+use symphonia_core::meta::MetadataLog;
 
 use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, MetaAtom};
 
@@ -21,10 +21,10 @@ pub struct UdtaAtom {
 }
 
 impl UdtaAtom {
-    /// Consume any metadata, and push it onto provided `MetadataQueue`.
-    pub fn take_metadata(&mut self, queue: &mut MetadataQueue) {
+    /// Consume any metadata, and push it onto provided `MetadataLog`.
+    pub fn take_metadata(&mut self, log: &mut MetadataLog) {
         if let Some(meta) = self.meta.take() {
-            meta.take_metadata(queue);
+            meta.take_metadata(log)
         }
     }
 }

--- a/symphonia-format-ogg/src/mappings/mod.rs
+++ b/symphonia-format-ogg/src/mappings/mod.rs
@@ -9,7 +9,7 @@ use super::common::OggPacket;
 
 use symphonia_core::codecs::CodecParameters;
 use symphonia_core::errors::Result;
-use symphonia_core::meta::Metadata;
+use symphonia_core::meta::MetadataRevision;
 
 mod flac;
 mod opus;
@@ -32,7 +32,7 @@ pub struct Bitstream {
 
 pub enum MapResult {
     Bitstream(Bitstream),
-    Metadata(Metadata),
+    Metadata(MetadataRevision),
     Unknown,
 }
 

--- a/symphonia-metadata/src/id3v2/mod.rs
+++ b/symphonia-metadata/src/id3v2/mod.rs
@@ -10,7 +10,7 @@
 use symphonia_core::support_metadata;
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::*;
-use symphonia_core::meta::{Metadata, MetadataBuilder, MetadataOptions, MetadataReader};
+use symphonia_core::meta::{MetadataRevision, MetadataBuilder, MetadataOptions, MetadataReader};
 use symphonia_core::probe::{QueryDescriptor, Descriptor, Instantiate};
 
 use log::{info, trace};
@@ -394,7 +394,7 @@ impl MetadataReader for Id3v2Reader {
         Id3v2Reader { }
     }
 
-    fn read_all(&mut self, reader: &mut MediaSourceStream) -> Result<Metadata> {
+    fn read_all(&mut self, reader: &mut MediaSourceStream) -> Result<MetadataRevision> {
         let mut builder = MetadataBuilder::new();
         read_id3v2(reader, &mut builder)?;
         Ok(builder.metadata())

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -287,21 +287,15 @@ fn pretty_print_format(path: &str, probed: &mut ProbeResult) {
         pretty_print_visuals(metadata_rev.visuals());
 
         // Warn that certain tags are preferred.
-        if probed.metadata.as_mut()
-            .map(|m| m.metadata())
-            .as_ref()
-            .map(|m| m.current())
-            .is_some() 
-        {
+        if probed.metadata.get().as_ref().is_some() {
             info!("tags that are part of the container format are preferentially printed.");
             info!("not printing additional tags that were found while probing.");
         }
     }
     else if let Some(metadata_rev) = probed.metadata
-        .as_mut()
-        .map(|m| m.metadata())
-        .as_ref().
-        and_then(|m| m.current()) 
+        .get()
+        .as_ref()
+        .and_then(|m| m.current()) 
     {
         pretty_print_tags(metadata_rev.tags());
         pretty_print_visuals(metadata_rev.visuals());

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -109,7 +109,7 @@ fn main() {
 
     // Probe the media source stream for metadata and get the format reader.
     match symphonia::default::get_probe().format(&hint, mss, &format_opts, &metadata_opts) {
-        Ok(probed) => {
+        Ok(mut probed) => {
             let result = if matches.is_present("verify-only") {
                 // Verify-only mode decodes and verifies the audio, but does not play it.
                 decode_only(probed.format, &DecoderOptions { verify: true, ..Default::default() })
@@ -120,12 +120,12 @@ fn main() {
             }
             else if matches.is_present("probe-only") {
                 // Probe-only mode only prints information about the format, tracks, metadata, etc.
-                pretty_print_format(path_str, &probed);
+                pretty_print_format(path_str, &mut probed);
                 Ok(())
             }
             else {
                 // Playback mode.
-                pretty_print_format(path_str, &probed);
+                pretty_print_format(path_str, &mut probed);
 
                 // If present, parse the seek argument.
                 let seek_time = matches.value_of("seek").map(|p| p.parse::<f64>().unwrap_or(0.0));
@@ -276,25 +276,35 @@ fn play(mut reader: Box<dyn FormatReader>, seek_time: Option<f64>, decode_option
     }
 }
 
-fn pretty_print_format(path: &str, probed: &ProbeResult) {
+fn pretty_print_format(path: &str, probed: &mut ProbeResult) {
     println!("+ {}", path);
     pretty_print_tracks(probed.format.tracks());
 
     // Prefer metadata that's provided in the container format, over other tags found during the
     // probe operation.
-    if let Some(metadata) = probed.format.metadata().current() {
-        pretty_print_tags(metadata.tags());
-        pretty_print_visuals(metadata.visuals());
+    if let Some(metadata_rev) = probed.format.metadata().current() {
+        pretty_print_tags(metadata_rev.tags());
+        pretty_print_visuals(metadata_rev.visuals());
 
         // Warn that certain tags are preferred.
-        if probed.metadata.as_ref().and_then(|m| m.current()).is_some() {
+        if probed.metadata.as_mut()
+            .map(|m| m.metadata())
+            .as_ref()
+            .map(|m| m.current())
+            .is_some() 
+        {
             info!("tags that are part of the container format are preferentially printed.");
             info!("not printing additional tags that were found while probing.");
         }
     }
-    else if let Some(metadata) = probed.metadata.as_ref().and_then(|m| m.current()) {
-        pretty_print_tags(metadata.tags());
-        pretty_print_visuals(metadata.visuals());
+    else if let Some(metadata_rev) = probed.metadata
+        .as_mut()
+        .map(|m| m.metadata())
+        .as_ref().
+        and_then(|m| m.current()) 
+    {
+        pretty_print_tags(metadata_rev.tags());
+        pretty_print_visuals(metadata_rev.visuals());
     }
 
     pretty_print_cues(probed.format.cues());


### PR DESCRIPTION
Hiya. When trying to bootstrap up a project with Symphonia I noticed an oddity/two with `MetadataQueue`. Its `pop()` method took an immutable reference, relying on the `RefCell` to get a mutable borrow, but the `push()` method took a mutable reference anyway. It seemed like an odd API disjoint, so I thought I'd try cleaning it up.

I chose to make `pop()` take a `&mut self` as well, to be consistent with most crates and to allow for the internals to be cleaned up. After that bit, there wasn't any need for the `RefCell` at all, so I removed it entirely. That also let me tweak `MetadataRef` to remove a panic, by just taking a regular reference.

In the end, `MetadataRef` seemed like it wasn't worth having anymore so I removed it in a separate commit. Happy to drop that if you think its too much. Unless users are holding these themselves though, there shouldn't be much of a migration path at all due to the previous `Deref` impl. 