### PR TITLE
Document when ProbeResult's metadata queue is empty

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Kostya Shishkov <kostya.shiskov@gmail.com>
 #
 # Please keep this section sorted in ascending order.
 
+BlackHoleFox [https://github.com/blackholefox]
 djugei [https://github.com/djugei]
 nicholaswyoung [https://github.com/nicholaswyoung]
 richardmitic [https://github.com/richardmitic]

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -161,7 +161,8 @@ pub struct ProbeResult {
     /// An instance of a `FormatReader` for the probed format
     pub format: Box<dyn FormatReader>,
     /// A queue of `Metadata` revisions read during the probe operation before the instantiation of
-    /// the `FormatReader`.
+    /// the `FormatReader`. If the container format was immediately determined, this will be empty and metadata
+    /// should be obtained by calling `.metadata()` on `format`.
     pub metadata: MetadataQueue
 }
 

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -161,10 +161,11 @@ pub struct ProbeResult {
     /// An instance of a `FormatReader` for the probed format
     pub format: Box<dyn FormatReader>,
     /// A queue of `Metadata` revisions read during the probe operation before the instantiation of
-    /// the `FormatReader`. If any additional metadata was present outside of the container, this is `Some` and the queue will have
-    /// at least one item in it.
+    /// the `FormatReader`. If any additional metadata was present outside of the container, this is
+    /// `Some` and the queue will have at least one item in it.
     ///
-    /// Metadata that was part of the container format itself can be read by calling `.metadata()` on `format`.
+    /// Metadata that was part of the container format itself can be read by calling `.metadata()`
+    /// on `format`.
     pub metadata: Option<MetadataQueue>,
 }
 
@@ -308,7 +309,8 @@ impl Probe {
 
                     let metadata = if metadata.current().is_some() {
                         Some(metadata)
-                    } else {
+                    }
+                    else {
                         None
                     };
 

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -287,12 +287,12 @@ fn pretty_print_format(path: &str, probed: &ProbeResult) {
         pretty_print_visuals(metadata.visuals());
 
         // Warn that certain tags are preferred.
-        if probed.metadata.current().is_some() {
+        if probed.metadata.as_ref().and_then(|m| m.current()).is_some() {
             info!("tags that are part of the container format are preferentially printed.");
             info!("not printing additional tags that were found while probing.");
         }
     }
-    else if let Some(metadata) = probed.metadata.current() {
+    else if let Some(metadata) = probed.metadata.as_ref().and_then(|m| m.current()) {
         pretty_print_tags(metadata.tags());
         pretty_print_visuals(metadata.visuals());
     }


### PR DESCRIPTION
When trying to use the library initially, it didn't seem clear that this would be empty all the time. It does make more sense if you read the `symphonia-player` example or look at the source, but it could probably gain from being more forward in the docs too.

Another idea: `ProbeResult` could be made into an enum instead, though this doesn't seem great and the docs are a simpler change since I don't think theres a real difference between the container being at the front of the stream and somewhere later after metadata, but I could be wrong there.
```rust
pub enum ProbeResult {
    InitalContainer {
        /// An instance of a `FormatReader` for the probed format.
        format: Box<dyn FormatReader>,
    },
    Container {
        /// An instance of a `FormatReader` for the probed format.
        format: Box<dyn FormatReader>,
        /// A queue of `Metadata` revisions read during the probe operation before the instantiation of
        /// the `FormatReader`. This queue will contain at least one item.
        metadata: MetadataQueue,
    }
}
```
