### PR TITLE
Add initial fuzzing harness

### DIFF
--- a/symphonia-bundle-flac/src/frame.rs
+++ b/symphonia-bundle-flac/src/frame.rs
@@ -199,7 +199,7 @@ pub fn read_frame_header<B: ByteStream>(reader: &mut B, sync: u16) -> Result<Fra
     // Get expected CRC8 checksum from the header.
     let crc8_expected = reader_crc8.into_inner().read_u8()?;
 
-    if crc8_expected != crc8_computed {
+    if crc8_expected != crc8_computed && cfg!(not(fuzzing)) {
         return decode_error("computed frame header CRC does not match expected CRC");
     }
 

--- a/symphonia-format-ogg/src/mappings/flac.rs
+++ b/symphonia-format-ogg/src/mappings/flac.rs
@@ -227,7 +227,7 @@ fn decode_frame_header(buf: &[u8]) -> Result<FrameHeader> {
     // Read the expected CRC-8 checksum from the frame header.
     let crc8_expected = reader_crc8.into_inner().read_u8()?;
 
-    if crc8_expected != crc8_computed {
+    if crc8_expected != crc8_computed && cfg!(not(fuzzing)) {
         return decode_error("ogg: flac computed frame header CRC does not match expected CRC");
     }
 

--- a/symphonia-format-ogg/src/physical.rs
+++ b/symphonia-format-ogg/src/physical.rs
@@ -78,7 +78,7 @@ impl PhysicalStream {
             // Get the calculated CRC for the page.
             let calculated_crc = reader_crc32.monitor().crc();
 
-            if self.page.crc != calculated_crc {
+            if self.page.crc != calculated_crc && cfg!(not(fuzzing)) {
                 warn!(
                     "crc mismatch: expected {:#x}, got {:#x}",
                     self.page.crc,

--- a/symphonia/fuzz/.gitignore
+++ b/symphonia/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/symphonia/fuzz/Cargo.toml
+++ b/symphonia/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.symphonia]
 path = ".."
+features = ["mp3", "aac"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/symphonia/fuzz/Cargo.toml
+++ b/symphonia/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "symphonia-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.symphonia]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "decode_any"
+path = "fuzz_targets/decode_any.rs"
+test = false
+doc = false

--- a/symphonia/fuzz/fuzz_targets/decode_any.rs
+++ b/symphonia/fuzz/fuzz_targets/decode_any.rs
@@ -1,0 +1,39 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+fuzz_target!(|data: Vec<u8>| {
+    let data = std::io::Cursor::new(data);
+
+    let source = symphonia::core::io::MediaSourceStream::new(Box::new(data), Default::default());
+
+    match symphonia::default::get_probe().format(
+        &Hint::new(),
+        source,
+        &FormatOptions::default(),
+        &MetadataOptions::default(),
+    ) {
+        Ok(mut probed) => {
+            let track = probed.format.default_track().unwrap();
+
+            let mut decoder = match symphonia::default::get_codecs()
+                .make(&track.codec_params, &DecoderOptions::default())
+            {
+                Ok(d) => d,
+                Err(_) => return,
+            };
+
+            loop {
+                let packet = match probed.format.next_packet() {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let _ = decoder.decode(&packet);
+            }
+        }
+        Err(_) => {}
+    }
+});


### PR DESCRIPTION
This, as-is, will try and fuzz all the default-enabled targets using the format guessing. This is *probably* good enough to not need one fuzzer target per format?