### PR TITLE
Replace deprecated constant in symphonia-play

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Kostya Shishkov <kostya.shiskov@gmail.com>
 # Please keep this section sorted in ascending order.
 
 djugei [https://github.com/djugei]
+Herohtar [https://github.com/herohtar]
 nicholaswyoung [https://github.com/nicholaswyoung]
 richardmitic [https://github.com/richardmitic]
 terrorfisch [https://github.com/terrorfisch]

--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -53,7 +53,7 @@ mod pulseaudio {
 
             // Create a PulseAudio stream specification.
             let pa_spec = pulse::sample::Spec {
-                format: pulse::sample::SAMPLE_FLOAT32NE,
+                format: pulse::sample::Format::FLOAT32NE,
                 channels: spec.channels.count() as u8,
                 rate: spec.rate,
             };


### PR DESCRIPTION
Minor change that replaces the deprecated PulseAudio format constant with the new one.