### PR TITLE
Remove unsafe code in chan_pair_mut

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Kostya Shishkov <kostya.shiskov@gmail.com>
 # Please keep this section sorted in ascending order.
 
 djugei [https://github.com/djugei]
+Herohtar [https://github.com/herohtar]
 nicholaswyoung [https://github.com/nicholaswyoung]
 richardmitic [https://github.com/richardmitic]
 terrorfisch [https://github.com/terrorfisch]

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -522,18 +522,14 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
         let first_idx = self.n_capacity * first;
         let second_idx = self.n_capacity * second;
 
-        // The AudioBuffer struct maintains the invariant that the underlying buffer is always 
-        // # of channels * n_capacity samples long. It also maintains the invariant that n_frames is
-        // always <= n_capacity. Therefore, so long as the first and second channel indicies are 
-        // unique and are strictly less than the AudioBuffer's channel count, it is safe to get
-        // mutable slices to each channel's respective part of the buffer.
-        assert!(first_idx < self.buf.len());
-        assert!(second_idx <self.buf.len());
+        if first_idx < second_idx {
+            let (a, b) = self.buf.split_at_mut(second_idx);
 
-        unsafe {
-            let ptr = self.buf.as_mut_ptr();
-            (slice::from_raw_parts_mut(ptr.add(first_idx), self.n_frames),
-             slice::from_raw_parts_mut(ptr.add(second_idx), self.n_frames))
+            (&mut a[first_idx..first_idx + self.n_frames], &mut b[..self.n_frames])
+        } else {
+            let (a, b) = self.buf.split_at_mut(first_idx);
+            
+            (&mut b[..self.n_frames], &mut a[second_idx..second_idx + self.n_frames])
         }
     }
 

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -526,7 +526,8 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
             let (a, b) = self.buf.split_at_mut(second_idx);
 
             (&mut a[first_idx..first_idx + self.n_frames], &mut b[..self.n_frames])
-        } else {
+        }
+        else {
             let (a, b) = self.buf.split_at_mut(first_idx);
             
             (&mut b[..self.n_frames], &mut a[second_idx..second_idx + self.n_frames])


### PR DESCRIPTION
Reduces unsafe code by 50%! :upside_down_face: 

The unsafe code block in `chan_pair_mut` can be removed by using `split_at_mut`. In order to preserve the original behavior of the method, a conditional needs to be used to split using the correct index depending on the order of the channels (0,1 vs 1,0). However, the code could be reduced if the method were changed to require the channels be requested in ascending order (first < second). The method is always called in that manner, but I wasn't sure if the ability to get channels in other combinations might be necessary in the future.