### PR TITLE
Fix symphonia-play Windows build

### DIFF
--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -139,7 +139,7 @@ mod cpal {
     trait AudioOutputSample :
         cpal::Sample +
         ConvertibleSample +
-        WriteSample +
+        RawSample +
         std::marker::Send +
         'static {}
 


### PR DESCRIPTION
Fixes a type that didn't get changed when `WriteSample` was replaced with `RawSample`