### PR TITLE
Run tests on PowerPC for big-endian coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,16 @@ jobs:
         args: --all --all-features --exclude symphonia-play
 
   test:
-    name: Test ${{ matrix.os }}
+    name: Test ${{ matrix.config.target }} on ${{ matrix.config.os }}
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, "windows-latest"]
+        config:
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false }
+          - { os: macos-latest, target: x86_64-apple-darwin, use-cross: false }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false }
+          - { os: ubuntu-latest, target: powerpc-unknown-linux-gnu, use-cross: true }
 
     steps:
       - name: Checkout
@@ -60,19 +64,22 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --exclude symphonia-play
+          args: --target ${{ matrix.config.target }} --all --exclude symphonia-play
+          use-cross: ${{ matrix.config.use-cross }}
 
       - name: Test all features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --exclude symphonia-play
+          args: --target ${{ matrix.config.target }} --all --all-features --exclude symphonia-play
+          use-cross: ${{ matrix.config.use-cross }}
 
       - name: Test documentation
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --doc --exclude symphonia-play
+          args: --target ${{ matrix.config.target }} --all --all-features --doc --exclude symphonia-play
+          use-cross: ${{ matrix.config.use-cross }}
 
 
 # Uncomment to check formatting

--- a/symphonia-core/src/io/mod.rs
+++ b/symphonia-core/src/io/mod.rs
@@ -232,21 +232,21 @@ pub trait ReadBytes {
         Ok(u64::from_be_bytes(buf))
     }
 
-    /// Reads four bytes from the stream and interprets them as a 32-bit little-endiann IEEE-754
+    /// Reads four bytes from the stream and interprets them as a 32-bit little-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
     fn read_f32(&mut self) -> io::Result<f32> {
         Ok(f32::from_le_bytes(self.read_quad_bytes()?))
     }
 
-    /// Reads four bytes from the stream and interprets them as a 32-bit big-endiann IEEE-754
+    /// Reads four bytes from the stream and interprets them as a 32-bit big-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
     fn read_be_f32(&mut self) -> io::Result<f32> {
         Ok(f32::from_be_bytes(self.read_quad_bytes()?))
     }
 
-    /// Reads four bytes from the stream and interprets them as a 64-bit little-endiann IEEE-754
+    /// Reads four bytes from the stream and interprets them as a 64-bit little-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
     fn read_f64(&mut self) -> io::Result<f64> {
@@ -255,7 +255,7 @@ pub trait ReadBytes {
         Ok(f64::from_le_bytes(buf))
     }
 
-    /// Reads four bytes from the stream and interprets them as a 64-bit big-endiann IEEE-754
+    /// Reads four bytes from the stream and interprets them as a 64-bit big-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
     fn read_be_f64(&mut self) -> io::Result<f64> {


### PR DESCRIPTION
The Cargo actions-rs package has a [nice hook-in](https://github.com/actions-rs/cargo#cross-compilation) for `cross`, which should let us run the tests on a big-endian architecture, in this case 32-bit PowerPC, pretty painlessly in CI.

This is currently based off https://github.com/pdeljanov/Symphonia/pull/48.

Closes #47 