### PR TITLE
AAC missing channel fix

### DIFF
--- a/symphonia-codec-aac/src/aac.rs
+++ b/symphonia-codec-aac/src/aac.rs
@@ -1616,6 +1616,9 @@ impl Decoder for AacDecoder {
             m4ainfo.read(extra_data_buf)?;
         }
         else {
+            validate!(params.sample_rate.is_some());
+            validate!(params.channels.is_some());
+
             // Otherwise, assume there is no ASC and use the codec parameters for ADTS.
             m4ainfo.srate = params.sample_rate.unwrap();
             m4ainfo.otype = M4AType::Lc;

--- a/symphonia-codec-aac/tests/tests.rs
+++ b/symphonia-codec-aac/tests/tests.rs
@@ -1,0 +1,37 @@
+use symphonia_core::codecs::{CodecParameters, Decoder, DecoderOptions};
+use symphonia_core::errors;
+use symphonia_core::formats::{FormatOptions, FormatReader};
+
+fn test_decode(data: Vec<u8>) -> symphonia_core::errors::Result<()> {
+    let data = std::io::Cursor::new(data);
+
+    let source = symphonia_core::io::MediaSourceStream::new(Box::new(data), Default::default());
+
+    let mut reader =
+        symphonia_codec_aac::AdtsReader::try_new(source, &FormatOptions::default())?;
+
+    let mut decoder = symphonia_codec_aac::AacDecoder::try_new(
+        &CodecParameters::default(),
+        &DecoderOptions::default(),
+    )?;
+
+    loop {
+        let packet = reader.next_packet()?;
+        let _ = decoder.decode(&packet);
+    }
+}
+
+#[test]
+fn invalid_channels_aac() {
+    let file = vec![
+        0xff, 0xf1, 0xaf, 0xce, 0x02, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xfb,
+        0xaf,
+    ];
+
+    let err = test_decode(file).unwrap_err();
+
+    match err {
+        errors::Error::DecodeError("aac: invalid data") => {}
+        e => panic!("Unexpected error {:?}", e),
+    }
+}


### PR DESCRIPTION
This fixes an error when decoding an invalid aac file found by the fuzzer.

The panic was on channels, but I assume validation of the sample rate existing here is also needed.