### PR TITLE
core: derive `PartialEq` for standard key types

### DIFF
--- a/symphonia-core/src/meta.rs
+++ b/symphonia-core/src/meta.rs
@@ -69,7 +69,7 @@ pub struct MetadataOptions {
 ///
 /// The visual types listed here are derived from, though do not entirely cover, the ID3v2 APIC
 /// frame specification.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StandardVisualKey {
     FileIcon,
     OtherIcon,
@@ -95,7 +95,7 @@ pub enum StandardVisualKey {
 /// `StandardTagKey` is an enumeration providing standardized keys for common tag types.
 /// A tag reader may assign a `StandardTagKey` to a `Tag` if the tag's key is generally
 /// accepted to map to a specific usage.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StandardTagKey {
     AcoustidFingerprint,
     AcoustidId,


### PR DESCRIPTION
Hi, this small PR derives `PartialEq` for the standard key metadata types. I'd like this for searching for a particular tag dynamically.