### PR TITLE
MP3: move bounds checks out of the hot loop

### DIFF
--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -8,7 +8,7 @@
 // Justification: Some loops are better expressed without a range loop.
 #![allow(clippy::needless_range_loop)]
 
-use std::f64;
+use std::{f64, convert::TryInto};
 
 use lazy_static::lazy_static;
 
@@ -322,7 +322,7 @@ pub(super) fn hybrid_synthesis(
             // Perform the 12-point IMDCT on each of the 3 short windows within the sub-band (6
             // samples each).
             let mut output = [0f32; 36];
-            imdct12_win(&samples[start..(start + 18)], window, &mut output);
+            imdct12_win(&samples[start..(start + 18)].try_into().unwrap(), window, &mut output);
 
             // Overlap the lower half of the IMDCT output (values 0..18) with the upper values of
             // the IMDCT (values 18..36) of the /previous/ iteration of the IMDCT.
@@ -336,8 +336,7 @@ pub(super) fn hybrid_synthesis(
 
 /// Performs the 12-point IMDCT, and windowing for each of the 3 short windows of a short block, and
 /// then overlap-adds the result.
-fn imdct12_win(x: &[f32], window: &[f32; 36], out: &mut [f32; 36]) {
-    debug_assert!(x.len() == 18);
+fn imdct12_win(x: &[f32; 18], window: &[f32; 36], out: &mut [f32; 36]) {
 
     let cos12 = &IMDCT_HALF_COS_12;
 

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -299,7 +299,7 @@ pub(super) fn hybrid_synthesis(
             let sub_band: &mut [f32; 18] = (&mut samples[start..(start + 18)]).try_into().unwrap();
 
             // Perform the 36-point on the entire sub-band.
-            imdct36::imdct36(&sub_band, &mut output);
+            imdct36::imdct36(sub_band, &mut output);
 
             // Overlap the lower half of the IMDCT output (values 0..18) with the upper values of
             // the IMDCT (values 18..36) of the /previous/ iteration of the IMDCT. While doing this
@@ -326,7 +326,7 @@ pub(super) fn hybrid_synthesis(
             // Perform the 12-point IMDCT on each of the 3 short windows within the sub-band (6
             // samples each).
             let mut output = [0f32; 36];
-            imdct12_win(&sub_band, window, &mut output);
+            imdct12_win(sub_band, window, &mut output);
 
             // Overlap the lower half of the IMDCT output (values 0..18) with the upper values of
             // the IMDCT (values 18..36) of the /previous/ iteration of the IMDCT.

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -294,6 +294,7 @@ pub(super) fn hybrid_synthesis(
 
         // For each of the 32 sub-bands (18 samples each)...
         for sb in 0..n_long_bands {
+            // casting to a know-size slice lets the compiler elide bounds checks
             let start = 18 * sb;
             let sub_band: &mut [f32; 18] = &mut samples[start..(start + 18)].try_into().unwrap();
 

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -297,7 +297,7 @@ pub(super) fn hybrid_synthesis(
             let start = 18 * sb;
 
             // Perform the 36-point on the entire sub-band.
-            imdct36::imdct36(&samples[start..(start + 18)], &mut output);
+            imdct36::imdct36(&samples[start..(start + 18)].try_into().unwrap(), &mut output);
 
             // Overlap the lower half of the IMDCT output (values 0..18) with the upper values of
             // the IMDCT (values 18..36) of the /previous/ iteration of the IMDCT. While doing this
@@ -535,8 +535,7 @@ mod imdct36 {
     /// Signal Processing, vol. 48, no. 10, pp. 990-994, 2001.
     ///
     /// https://ieeexplore.ieee.org/document/974789
-    pub fn imdct36(x: &[f32], y: &mut [f32; 36]) {
-        debug_assert!(x.len() == 18);
+    pub fn imdct36(x: &[f32; 18], y: &mut [f32; 36]) {
 
         let mut dct = [0f32; 18];
 
@@ -568,8 +567,7 @@ mod imdct36 {
     /// Continutation of `imdct36`.
     ///
     /// Step 2: Mapping N/2-point DCT-IV to N/2-point SDCT-II.
-    fn dct_iv(x: &[f32], y: &mut [f32; 18]) {
-        debug_assert!(x.len() == 18);
+    fn dct_iv(x: &[f32; 18], y: &mut [f32; 18]) {
 
         // Scale factors for input samples. Computed from (16).
         // 2 * cos(PI * (2*m + 1) / (2*36)

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -296,7 +296,7 @@ pub(super) fn hybrid_synthesis(
         for sb in 0..n_long_bands {
             // casting to a know-size slice lets the compiler elide bounds checks
             let start = 18 * sb;
-            let sub_band: &mut [f32; 18] = &mut samples[start..(start + 18)].try_into().unwrap();
+            let sub_band: &mut [f32; 18] = (&mut samples[start..(start + 18)]).try_into().unwrap();
 
             // Perform the 36-point on the entire sub-band.
             imdct36::imdct36(&sub_band, &mut output);
@@ -321,7 +321,7 @@ pub(super) fn hybrid_synthesis(
         for sb in n_long_bands..32 {
             // casting to a know-size slice lets the compiler elide bounds checks
             let start = 18 * sb;
-            let sub_band: &mut [f32; 18] = &mut samples[start..(start + 18)].try_into().unwrap();
+            let sub_band: &mut [f32; 18] = (&mut samples[start..(start + 18)]).try_into().unwrap();
 
             // Perform the 12-point IMDCT on each of the 3 short windows within the sub-band (6
             // samples each).

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -8,7 +8,7 @@
 // Justification: Some loops are better expressed without a range loop.
 #![allow(clippy::needless_range_loop)]
 
-use std::{f64, convert::TryInto};
+use std::{convert::TryInto, f64};
 
 use lazy_static::lazy_static;
 
@@ -341,7 +341,6 @@ pub(super) fn hybrid_synthesis(
 /// Performs the 12-point IMDCT, and windowing for each of the 3 short windows of a short block, and
 /// then overlap-adds the result.
 fn imdct12_win(x: &[f32; 18], window: &[f32; 36], out: &mut [f32; 36]) {
-
     let cos12 = &IMDCT_HALF_COS_12;
 
     for w in 0..3 {
@@ -540,7 +539,6 @@ mod imdct36 {
     ///
     /// https://ieeexplore.ieee.org/document/974789
     pub fn imdct36(x: &[f32; 18], y: &mut [f32; 36]) {
-
         let mut dct = [0f32; 18];
 
         dct_iv(x, &mut dct);
@@ -572,7 +570,6 @@ mod imdct36 {
     ///
     /// Step 2: Mapping N/2-point DCT-IV to N/2-point SDCT-II.
     fn dct_iv(x: &[f32; 18], y: &mut [f32; 18]) {
-
         // Scale factors for input samples. Computed from (16).
         // 2 * cos(PI * (2*m + 1) / (2*36)
         const SCALE: [f32; 18] = [

--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -295,15 +295,16 @@ pub(super) fn hybrid_synthesis(
         // For each of the 32 sub-bands (18 samples each)...
         for sb in 0..n_long_bands {
             let start = 18 * sb;
+            let sub_band: &mut [f32; 18] = &mut samples[start..(start + 18)].try_into().unwrap();
 
             // Perform the 36-point on the entire sub-band.
-            imdct36::imdct36(&samples[start..(start + 18)].try_into().unwrap(), &mut output);
+            imdct36::imdct36(&sub_band, &mut output);
 
             // Overlap the lower half of the IMDCT output (values 0..18) with the upper values of
             // the IMDCT (values 18..36) of the /previous/ iteration of the IMDCT. While doing this
             // also apply the window.
             for i in 0..18 {
-                samples[start + i] = overlap[sb][i] + (output[i] * window[i]);
+                sub_band[i] = overlap[sb][i] + (output[i] * window[i]);
                 overlap[sb][i] = output[18 + i] * window[18 + i];
             }
         }


### PR DESCRIPTION
Move bounds checks out of the hot loop to be performed only once outside it. This should provide a modest performance boost, especially on CPUs with less powerful speculative execution.

Reduces the output of `cargo asm` for this function from 488 to 412 lines, when annotated with `#[inline(never)]` to make it easy to inspect.

<details>
  <summary>Instruction counts before</summary>
    125 movss
     92 mov
     85 lea
     25 cmp
     18 call
     16 mulss
     14 xor
     14 jmp
     13 addss
     11 jne
      6 ud2
      6 push
      6 pop
      6 jae
      5 jb
      5 add
      3 je
      1 subss
      1 sub
      1 ret
</details>


<details>
  <summary>Instruction counts after</summary>
    125 movss
     74 lea
     68 mov
     16 mulss
     14 xor
     14 jmp
     14 cmp
     13 addss
     12 call
     11 jne
      6 push
      6 pop
      5 add
      3 je
      1 subss
      1 sub
      1 ret
</details>

This doesn't introduce any new panics - the code would have panicked anyway, now the check is simply performed once per function call outside the hot loop.

There might be a more elegant iterator-based way than `.try_into().unwrap()`; I haven't really looked into it.

**Many other functions** in this file can be given a similar treatment; this should provide a total boost of a few % in terms of performance for end-to-end decoding. This PR is meant to demonstrate the approach. I could proceed with converting the rest to this idiom, if you wish.