### PR TITLE
core/audio/RawSampleBuffer: allow using external storage

### DIFF
--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -42,7 +42,7 @@ mod pulseaudio {
 
     pub struct PulseAudioOutput {
         pa: psimple::Simple,
-        sample_buf: RawSampleBuffer<f32>,
+        sample_buf: RawSampleBuffer<'static, f32>,
     }
 
     impl PulseAudioOutput {


### PR DESCRIPTION
@pdeljanov: many thanks for the awesome crates!

I'm working on a Symphonia based GStreamer plugin ([WIP branch](https://gitlab.freedesktop.org/fengalin/gst-plugins-rs/-/tree/symphonia)). So far, I've integrated the FLAC and MP3 decoders, which can already be used in pipelines as drop-in replacements for any other similar decoders. My plan would be to integrate the other coders with "excellent" status and probably demuxers too. But before going any further, I'd like to get your feeling about this.

I'd also want to propose a modification that would make the integration a bit more optimal IMHO. Quoting the commit message:

> GStreamer uses its own Buffers which are handed to the downstream
nodes in the processing graph. The nodes (elements) can be implemented
in mutiple languages and the Buffers can be allocated elsewhere or be
part of a Buffer pool.
> 
> RawSampleBuffer provides a convenient mechanism to export decoded
buffers to an unaligned bytes stream. In order to ensure data
safety, the RawSampleBuffer manages its own sample storage and
provides an accessor to obtain an immutable byte slice on the
resulting data.
> 
> When used in frameworks such as GStreamer, the byte slice must be
copied to the target Buffer.
> 
> The changes in this commit allow using the RawSampleBuffer with
an external byte slice, thus avoiding the last copy.

I left open questions in the code (see `FIXME`s). After a back and forth, I decided to use an `&mut [u8]` for the external storage type, but I also considered `&mut [S::RawType]`. Reasons why I settle to `&mut [u8]` are:

- We can still ensure safety by carefully checking the available size.
- It's more convenient for callers: otherwise, they would most likely need to cast their slice using an external crate and `Symphonia` already makes use of such a crate.
- This is symmetric to the output type returned by `RawSampleBuffer::as_bytes`.

Is this acceptable to you?