### PR TITLE
mkv: Fix forward seeks with read-only MediaSources

### DIFF
--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -184,7 +184,7 @@ impl MkvReader {
                 Some(block) => block.pos,
                 None => cluster.pos,
             };
-            self.iter.seek(pos)?;
+            self.iter.seek(pos, self.iter.inner().is_seekable())?;
 
             // Restore cluster's metadata
             self.current_cluster =
@@ -389,7 +389,7 @@ impl FormatReader for MkvReader {
             seek_positions.sort_by_key(|sp| sp.1);
 
             for (etype, pos) in seek_positions {
-                it.seek(pos)?;
+                it.seek(pos, is_seekable)?;
                 match etype {
                     ElementType::Tracks => {
                         segment_tracks = Some(it.read_element::<TracksElement>()?);

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -184,7 +184,7 @@ impl MkvReader {
                 Some(block) => block.pos,
                 None => cluster.pos,
             };
-            self.iter.seek(pos, self.iter.inner().is_seekable())?;
+            self.iter.seek(pos)?;
 
             // Restore cluster's metadata
             self.current_cluster =
@@ -389,7 +389,7 @@ impl FormatReader for MkvReader {
             seek_positions.sort_by_key(|sp| sp.1);
 
             for (etype, pos) in seek_positions {
-                it.seek(pos, is_seekable)?;
+                it.seek(pos)?;
                 match etype {
                     ElementType::Tracks => {
                         segment_tracks = Some(it.read_element::<TracksElement>()?);

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -7,7 +7,7 @@
 
 use std::io::{Seek, SeekFrom};
 
-use symphonia_core::errors::{decode_error, Error, Result};
+use symphonia_core::errors::{decode_error, seek_error, Error, Result, SeekErrorKind};
 use symphonia_core::io::ReadBytes;
 use symphonia_core::util::bits::sign_extend_leq64_to_i64;
 
@@ -251,14 +251,25 @@ impl<R: ReadBytes> ElementIterator<R> {
     }
 
     /// Seek to a specified offset inside of the stream.
-    pub(crate) fn seek(&mut self, pos: u64) -> Result<()>
+    pub(crate) fn seek(&mut self, pos: u64, is_seekable: bool) -> Result<()>
     where
         R: Seek,
     {
+        let current_pos = self.pos();
         self.current = None;
-        self.reader.seek(SeekFrom::Start(pos))?;
+        if is_seekable {
+            self.reader.seek(SeekFrom::Start(pos))?;
+        } else if pos < current_pos {
+            return seek_error(SeekErrorKind::ForwardOnly);
+        } else {
+            self.reader.ignore_bytes(pos - current_pos)?;
+        }
         self.next_pos = pos;
         Ok(())
+    }
+
+    pub(crate) fn inner(&self) -> &R {
+        &self.reader
     }
 
     /// Consumes this iterator and return the original stream.

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -259,9 +259,11 @@ impl<R: ReadBytes> ElementIterator<R> {
         self.current = None;
         if is_seekable {
             self.reader.seek(SeekFrom::Start(pos))?;
-        } else if pos < current_pos {
+        }
+        else if pos < current_pos {
             return seek_error(SeekErrorKind::ForwardOnly);
-        } else {
+        }
+        else {
             self.reader.ignore_bytes(pos - current_pos)?;
         }
         self.next_pos = pos;

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -5,10 +5,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::io::{Seek, SeekFrom};
+use std::io::SeekFrom;
 
 use symphonia_core::errors::{decode_error, seek_error, Error, Result, SeekErrorKind};
-use symphonia_core::io::ReadBytes;
+use symphonia_core::io::{MediaSource, ReadBytes};
 use symphonia_core::util::bits::sign_extend_leq64_to_i64;
 
 use crate::element_ids::{ElementType, Type, ELEMENTS};
@@ -251,13 +251,13 @@ impl<R: ReadBytes> ElementIterator<R> {
     }
 
     /// Seek to a specified offset inside of the stream.
-    pub(crate) fn seek(&mut self, pos: u64, is_seekable: bool) -> Result<()>
+    pub(crate) fn seek(&mut self, pos: u64) -> Result<()>
     where
-        R: Seek,
+        R: MediaSource,
     {
         let current_pos = self.pos();
         self.current = None;
-        if is_seekable {
+        if self.reader.is_seekable() {
             self.reader.seek(SeekFrom::Start(pos))?;
         }
         else if pos < current_pos {
@@ -268,10 +268,6 @@ impl<R: ReadBytes> ElementIterator<R> {
         }
         self.next_pos = pos;
         Ok(())
-    }
-
-    pub(crate) fn inner(&self) -> &R {
-        &self.reader
     }
 
     /// Consumes this iterator and return the original stream.


### PR DESCRIPTION
Read-only sources were mistakenly calling `Seek::seek` if an MkvReader's `clusters` had been populated, causing a seek error even if the target timestamp occurs later in the stream.

This PR changes the EBML iterator to consume bytes if the source is not seekable *and* the destination can be forward-skipped to, otherwise returning `ForwardOnly`.