### PR TITLE
Fix clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -39,3 +39,4 @@
 #   they're instructive to the reader and improve the code aesthetics.
 #
 # --------------------------------------------------------------------------------------------------
+msrv = "1.53"

--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -345,8 +345,8 @@ fn read_subframe<B: ReadBitsLtr>(bs: &mut B, frame_bps: u32, buf: &mut [i32]) ->
     match subframe_type {
         SubFrameType::Constant => decode_constant(bs, bps, buf)?,
         SubFrameType::Verbatim => decode_verbatim(bs, bps, buf)?,
-        SubFrameType::FixedLinear(order) => decode_fixed_linear(bs, bps, order as u32, buf)?,
-        SubFrameType::Linear(order) => decode_linear(bs, bps, order as u32, buf)?,
+        SubFrameType::FixedLinear(order) => decode_fixed_linear(bs, bps, order, buf)?,
+        SubFrameType::Linear(order) => decode_linear(bs, bps, order, buf)?,
     };
 
     // Shift the samples to account for the dropped bits.

--- a/symphonia-bundle-flac/src/validate.rs
+++ b/symphonia-bundle-flac/src/validate.rs
@@ -48,7 +48,7 @@ impl Validator {
         let n_frames = buf.frames();
 
         // Calculate the total size of all the samples in bytes.
-        let buf_len = (n_channels * n_frames * bytes_per_sample) as usize;
+        let buf_len = n_channels * n_frames * bytes_per_sample;
 
         // Ensure the byte buffer length can accomodate all the samples.
         if self.buf.len() < buf_len {

--- a/symphonia-bundle-mp3/src/common.rs
+++ b/symphonia-bundle-mp3/src/common.rs
@@ -12,7 +12,7 @@ use symphonia_core::errors::Result;
 use symphonia_core::io::BufReader;
 
 /// The MPEG audio version.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MpegVersion {
     /// Version 2.5
     Mpeg2p5,
@@ -23,7 +23,7 @@ pub enum MpegVersion {
 }
 
 /// The MPEG audio layer.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MpegLayer {
     /// Layer 1
     Layer1,
@@ -35,7 +35,7 @@ pub enum MpegLayer {
 
 /// For Joint Stereo channel mode, the mode extension describes the features and parameters of the
 /// stereo encoding.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Mode {
     /// Joint Stereo in layer 3 may use both Mid-Side and Intensity encoding.
     Layer3 { mid_side: bool, intensity: bool },
@@ -45,7 +45,7 @@ pub enum Mode {
 }
 
 /// The channel mode.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ChannelMode {
     /// Single mono audio channel.
     Mono,
@@ -78,7 +78,7 @@ impl ChannelMode {
 }
 
 /// The emphasis applied during encoding.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Emphasis {
     /// No emphasis
     None,

--- a/symphonia-bundle-mp3/src/decoder.rs
+++ b/symphonia-bundle-mp3/src/decoder.rs
@@ -35,7 +35,7 @@ enum State {
     #[cfg(feature = "mp2")]
     Layer2(layer2::Layer2),
     #[cfg(feature = "mp3")]
-    Layer3(layer3::Layer3),
+    Layer3(Box<layer3::Layer3>),
 }
 
 impl State {
@@ -46,7 +46,7 @@ impl State {
             #[cfg(feature = "mp2")]
             CODEC_TYPE_MP2 => State::Layer2(layer2::Layer2::new()),
             #[cfg(feature = "mp3")]
-            CODEC_TYPE_MP3 => State::Layer3(layer3::Layer3::new()),
+            CODEC_TYPE_MP3 => State::Layer3(Box::new(layer3::Layer3::new())),
             _ => unreachable!(),
         }
     }

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -181,7 +181,9 @@ impl FormatReader for MpaReader {
                     continue;
                 }
             }
-            else if is_maybe_vbri_tag(&packet, &header) && try_read_vbri_tag(&packet, &header).is_some() {
+            else if is_maybe_vbri_tag(&packet, &header)
+                && try_read_vbri_tag(&packet, &header).is_some()
+            {
                 // Discard the packet and tag since it was not at the start of the stream.
                 warn!("found an unexpected vbri tag, discarding");
                 continue;

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -181,12 +181,10 @@ impl FormatReader for MpaReader {
                     continue;
                 }
             }
-            else if is_maybe_vbri_tag(&packet, &header) {
-                if try_read_vbri_tag(&packet, &header).is_some() {
-                    // Discard the packet and tag since it was not at the start of the stream.
-                    warn!("found an unexpected vbri tag, discarding");
-                    continue;
-                }
+            else if is_maybe_vbri_tag(&packet, &header) && try_read_vbri_tag(&packet, &header).is_some() {
+                // Discard the packet and tag since it was not at the start of the stream.
+                warn!("found an unexpected vbri tag, discarding");
+                continue;
             }
 
             break (header, packet);

--- a/symphonia-bundle-mp3/src/layer1/mod.rs
+++ b/symphonia-bundle-mp3/src/layer1/mod.rs
@@ -99,14 +99,14 @@ impl Layer for Layer1 {
 
         // Read bit allocations for each non-intensity coded sub-bands.
         for sb in 0..bound {
-            for ch in 0..num_channels {
+            for chan in &mut alloc {
                 let bits = bs.read_bits_leq32(4)? as u8;
 
                 if bits > 0xe {
                     return decode_error("mp1: invalid bit allocation");
                 }
 
-                alloc[ch][sb] = if bits != 0 { bits + 1 } else { 0 };
+                chan[sb] = if bits != 0 { bits + 1 } else { 0 };
             }
         }
 
@@ -182,9 +182,9 @@ impl Layer for Layer1 {
         // infalliable.
         out.render_reserved(Some(384));
 
-        for ch in 0..num_channels {
+        for (ch, samples) in samples.iter().enumerate().take(num_channels) {
             // Perform polyphase synthesis and generate PCM samples.
-            synthesis::synthesis(&mut self.synthesis[ch], 12, &samples[ch], out.chan_mut(ch));
+            synthesis::synthesis(&mut self.synthesis[ch], 12, samples, out.chan_mut(ch));
         }
 
         Ok(())

--- a/symphonia-bundle-mp3/src/layer3/mod.rs
+++ b/symphonia-bundle-mp3/src/layer3/mod.rs
@@ -462,7 +462,7 @@ impl Layer for Layer3 {
                 synthesis::synthesis(
                     &mut self.synthesis[ch],
                     18,
-                    &mut self.samples[gr][ch],
+                    &self.samples[gr][ch],
                     &mut out_ch_samples[(gr * 576)..((gr + 1) * 576)],
                 );
             }

--- a/symphonia-bundle-mp3/src/layer3/requantize.rs
+++ b/symphonia-bundle-mp3/src/layer3/requantize.rs
@@ -76,8 +76,8 @@ pub(super) fn read_huffman_samples<B: ReadBitsLtr>(
     // There are up-to 3 regions in the big_value partition. Determine the sample index denoting the
     // end of each region (non-inclusive). Clamp to the end of the big_values partition.
     let regions: [usize; 3] = [
-        min(channel.region1_start as usize, big_values_len),
-        min(channel.region2_start as usize, big_values_len),
+        min(channel.region1_start, big_values_len),
+        min(channel.region2_start, big_values_len),
         min(576, big_values_len),
     ];
 

--- a/symphonia-bundle-mp3/src/synthesis.rs
+++ b/symphonia-bundle-mp3/src/synthesis.rs
@@ -852,16 +852,17 @@ mod tests {
     use std::f64;
 
     fn dct32_analytical(x: &[f32; 32]) -> [f32; 32] {
-        const PI_32: f64 = f64::consts::PI / 32.0;
+        const PI_32: f32 = (f64::consts::PI / 32.0) as f32;
 
         let mut result = [0f32; 32];
-        for i in 0..32 {
-            let mut sum = 0.0;
-            for j in 0..32 {
-                sum += (x[j] as f64) * (PI_32 * (i as f64) * ((j as f64) + 0.5)).cos();
-            }
-            result[i] = sum as f32;
+        for (i, item) in result.iter_mut().enumerate() {
+            *item = x
+                .iter()
+                .enumerate()
+                .map(|(j, &jtem)| ((jtem) * (PI_32 * (i as f32) * ((j as f32) + 0.5)).cos()) as f32)
+                .sum();
         }
+
         result
     }
 

--- a/symphonia-bundle-mp3/src/synthesis.rs
+++ b/symphonia-bundle-mp3/src/synthesis.rs
@@ -852,14 +852,14 @@ mod tests {
     use std::f64;
 
     fn dct32_analytical(x: &[f32; 32]) -> [f32; 32] {
-        const PI_32: f32 = (f64::consts::PI / 32.0) as f32;
+        const PI_32: f64 = f64::consts::PI / 32.0;
 
         let mut result = [0f32; 32];
         for (i, item) in result.iter_mut().enumerate() {
             *item = x
                 .iter()
                 .enumerate()
-                .map(|(j, &jtem)| ((jtem) * (PI_32 * (i as f32) * ((j as f32) + 0.5)).cos()))
+                .map(|(j, &jtem)| jtem * (PI_32 * (i as f64) * ((j as f64) + 0.5)).cos() as f32)
                 .sum();
         }
 

--- a/symphonia-bundle-mp3/src/synthesis.rs
+++ b/symphonia-bundle-mp3/src/synthesis.rs
@@ -859,7 +859,7 @@ mod tests {
             *item = x
                 .iter()
                 .enumerate()
-                .map(|(j, &jtem)| ((jtem) * (PI_32 * (i as f32) * ((j as f32) + 0.5)).cos()) as f32)
+                .map(|(j, &jtem)| ((jtem) * (PI_32 * (i as f32) * ((j as f32) + 0.5)).cos()))
                 .sum();
         }
 

--- a/symphonia-check/src/main.rs
+++ b/symphonia-check/src/main.rs
@@ -358,7 +358,7 @@ fn main() {
             Arg::new("decoder")
                 .long("ref")
                 .takes_value(true)
-                .possible_values(&["ffmpeg", "flac", "mpg123", "oggdec"])
+                .possible_values(["ffmpeg", "flac", "mpg123", "oggdec"])
                 .default_value("ffmpeg")
                 .help("Specify a particular decoder to be used as the reference"),
         )

--- a/symphonia-codec-aac/src/aac/common.rs
+++ b/symphonia-codec-aac/src/aac/common.rs
@@ -89,7 +89,7 @@ impl Lcg {
     #[inline(always)]
     pub fn next(&mut self) -> i32 {
         // Numerical Recipes LCG parameters.
-        self.state = (self.state as u32).wrapping_mul(1664525).wrapping_add(1013904223);
+        self.state = self.state.wrapping_mul(1664525).wrapping_add(1013904223);
         self.state as i32
     }
 }

--- a/symphonia-codec-aac/src/aac/mod.rs
+++ b/symphonia-codec-aac/src/aac/mod.rs
@@ -353,9 +353,9 @@ impl AacDecoder {
                     // ID_DSE
                     let _id = bs.read_bits_leq32(4)?;
                     let align = bs.read_bool()?;
-                    let mut count = bs.read_bits_leq32(8)? as u32;
+                    let mut count = bs.read_bits_leq32(8)?;
                     if count == 255 {
-                        count += bs.read_bits_leq32(8)? as u32;
+                        count += bs.read_bits_leq32(8)?;
                     }
                     if align {
                         bs.realign(); // ????

--- a/symphonia-codec-adpcm/src/codec_ima.rs
+++ b/symphonia-codec-adpcm/src/codec_ima.rs
@@ -54,7 +54,7 @@ impl AdpcmImaBlockStatus {
         let diff = ((2 * delta + 1) * step) >> 3;
         let predictor = if sign { self.predictor - diff } else { self.predictor + diff };
         self.predictor = clamp_i16(predictor) as i32;
-        self.step_index = (self.step_index + IMA_INDEX_TABLE[nibble as usize]).min(88).max(0);
+        self.step_index = (self.step_index + IMA_INDEX_TABLE[nibble as usize]).clamp(0, 88);
         from_i16_shift!(self.predictor)
     }
 }

--- a/symphonia-codec-vorbis/src/codebook.rs
+++ b/symphonia-codec-vorbis/src/codebook.rs
@@ -431,7 +431,7 @@ mod tests {
     fn verify_synthesize_codewords() {
         const CODEWORD_LENGTHS: &[u8] = &[2, 4, 4, 4, 4, 2, 3, 3];
         const EXPECTED_CODEWORDS: &[u32] = &[0, 0x4, 0x5, 0x6, 0x7, 0x2, 0x6, 0x7];
-        let codewords = synthesize_codewords(&CODEWORD_LENGTHS).unwrap();
+        let codewords = synthesize_codewords(CODEWORD_LENGTHS).unwrap();
         assert_eq!(&codewords, EXPECTED_CODEWORDS);
     }
 }

--- a/symphonia-codec-vorbis/src/common.rs
+++ b/symphonia-codec-vorbis/src/common.rs
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(bitset.count(), 0);
 
         for _ in bitset.iter() {
-            assert!(false);
+            panic!("Should be empty!");
         }
 
         bitset.set(1);

--- a/symphonia-codec-vorbis/src/floor.rs
+++ b/symphonia-codec-vorbis/src/floor.rs
@@ -227,7 +227,7 @@ impl Floor for Floor0 {
             }
 
             // Get the codebook for this floor.
-            let codebook = &codebooks[codebook_idx as usize];
+            let codebook = &codebooks[codebook_idx];
 
             let order = usize::from(self.setup.floor0_order);
             let mut i = 0;

--- a/symphonia-codec-vorbis/src/floor.rs
+++ b/symphonia-codec-vorbis/src/floor.rs
@@ -776,7 +776,7 @@ fn find_neighbors(vec: &[u32], x: usize) -> (usize, usize) {
 fn render_point(x0: u32, y0: i32, x1: u32, y1: i32, x: u32) -> i32 {
     let dy = y1 - y0;
     let adx = x1 - x0;
-    let err = dy.abs() as u32 * (x - x0);
+    let err = dy.unsigned_abs() * (x - x0);
     let off = err / adx;
     if dy < 0 {
         y0 - off as i32

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -160,7 +160,7 @@ impl Layout {
 }
 
 /// `SignalSpec` describes the characteristics of a Signal.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SignalSpec {
     /// The signal sampling rate in hertz (Hz).
     pub rate: u32,

--- a/symphonia-core/src/conv.rs
+++ b/symphonia-core/src/conv.rs
@@ -615,7 +615,7 @@ impl_convert!(f32, f64, s, s as f64); // f64
 impl_convert!(f64, u8, s, ((s.clamped() + 1.0) * 128.0) as u8); // u8
 impl_convert!(f64, u16, s, ((s.clamped() + 1.0) * 32_768.0) as u16); // u16
 impl_convert!(f64, u24, s, u24::from(((s.clamped() + 1.0) * 8_388_608.0) as u32)); // u24
-impl_convert!(f64, u32, s, (s.clamped() + 1.0 * 2_147_483_648.0) as u32); // u32
+impl_convert!(f64, u32, s, ((s.clamped() + 1.0) * 2_147_483_648.0) as u32); // u32
 
 impl_convert!(f64, i8, s, (s.clamped() * 128.0) as i8); // i8
 impl_convert!(f64, i16, s, (s.clamped() * 32_768.0) as i16); // i16

--- a/symphonia-core/src/conv.rs
+++ b/symphonia-core/src/conv.rs
@@ -483,7 +483,7 @@ fn i16_to_u16(s: i16) -> u16 {
 }
 
 impl_convert!(i16, u8, s, (i16_to_u16(s) >> 8) as u8); // u8
-impl_convert!(i16, u16, s, i16_to_u16(s) as u16); // u16
+impl_convert!(i16, u16, s, i16_to_u16(s)); // u16
 impl_convert!(i16, u24, s, u24::from((i16_to_u16(s) as u32) << 8)); // u24
 impl_convert!(i16, u32, s, (i16_to_u16(s) as u32) << 16); // u32
 
@@ -510,7 +510,7 @@ impl_convert!(i24, u32, s, i24_to_u32(s)); // u32
 impl_convert!(i24, i8, s, (s.clamped().inner() >> 16) as i8); // i8
 impl_convert!(i24, i16, s, (s.clamped().inner() >> 8) as i16); // i16
 impl_convert!(i24, i24, s, s); // i24
-impl_convert!(i24, i32, s, (s.clamped().inner() as i32) << 8); // i32
+impl_convert!(i24, i32, s, (s.clamped().inner()) << 8); // i32
 
 impl_convert!(i24, f32, s, s.clamped().inner() as f32 / 8_388_608.0); // f32
 impl_convert!(i24, f64, s, s.clamped().inner() as f64 / 8_388_608.0); // f64
@@ -529,11 +529,11 @@ impl_convert!(i32, u32, s, i32_to_u32(s)); // u32
 
 impl_convert!(i32, i8, s, (s >> 24) as i8); // i8
 impl_convert!(i32, i16, s, (s >> 16) as i16); // i16
-impl_convert!(i32, i24, s, i24::from((s >> 8) as i32)); // i24
+impl_convert!(i32, i24, s, i24::from(s >> 8)); // i24
 impl_convert!(i32, i32, s, s); // i32
 
 impl_convert!(i32, f32, s, (s as f64 / 2_147_483_648.0) as f32); // f32
-impl_convert!(i32, f64, s, (s as f64 / 2_147_483_648.0) as f64); // f64
+impl_convert!(i32, f64, s, s as f64 / 2_147_483_648.0); // f64
 
 // u8 to ...
 
@@ -584,7 +584,7 @@ impl_convert!(u24, f64, s, ((s.clamped().inner() as f64) / 8_388_608.0) - 1.0); 
 
 impl_convert!(u32, u8, s, (s >> 24) as u8); // u8
 impl_convert!(u32, u16, s, (s >> 16) as u16); // u16
-impl_convert!(u32, u24, s, u24::from((s >> 8) as u32)); // u24
+impl_convert!(u32, u24, s, u24::from(s >> 8)); // u24
 impl_convert!(u32, u32, s, s); // u32
 
 impl_convert!(u32, i8, s, (s.wrapping_sub(0x8000_0000) >> 24) as i8); // i8
@@ -615,7 +615,7 @@ impl_convert!(f32, f64, s, s as f64); // f64
 impl_convert!(f64, u8, s, ((s.clamped() + 1.0) * 128.0) as u8); // u8
 impl_convert!(f64, u16, s, ((s.clamped() + 1.0) * 32_768.0) as u16); // u16
 impl_convert!(f64, u24, s, u24::from(((s.clamped() + 1.0) * 8_388_608.0) as u32)); // u24
-impl_convert!(f64, u32, s, ((s.clamped() + 1.0) as f64 * 2_147_483_648.0) as u32); // u32
+impl_convert!(f64, u32, s, (s.clamped() + 1.0 * 2_147_483_648.0) as u32); // u32
 
 impl_convert!(f64, i8, s, (s.clamped() * 128.0) as i8); // i8
 impl_convert!(f64, i16, s, (s.clamped() * 32_768.0) as i16); // i16

--- a/symphonia-core/src/dsp/fft.rs
+++ b/symphonia-core/src/dsp/fft.rs
@@ -110,7 +110,7 @@ impl Fft {
         }
 
         // Do the forward FFT.
-        self.transform(y, n);
+        Self::transform(y, n);
 
         // Output scale.
         let c = 1.0 / n as f32;
@@ -139,7 +139,7 @@ impl Fft {
         }
 
         // Do the forward FFT.
-        self.transform(x, n);
+        Self::transform(x, n);
 
         // Output scale.
         let c = 1.0 / n as f32;
@@ -170,7 +170,7 @@ impl Fft {
             4 => fft4(x.try_into().unwrap()),
             8 => fft8(x.try_into().unwrap()),
             16 => fft16(x.try_into().unwrap()),
-            _ => self.transform(x, n),
+            _ => Self::transform(x, n),
         }
     }
 
@@ -192,11 +192,11 @@ impl Fft {
             4 => fft4(y.try_into().unwrap()),
             8 => fft8(y.try_into().unwrap()),
             16 => fft16(y.try_into().unwrap()),
-            _ => self.transform(y, n),
+            _ => Self::transform(y, n),
         }
     }
 
-    fn transform(&self, x: &mut [Complex], n: usize) {
+    fn transform(x: &mut [Complex], n: usize) {
         fn to_arr(x: &mut [Complex]) -> Option<&mut [Complex; 32]> {
             x.try_into().ok()
         }
@@ -209,8 +209,8 @@ impl Fft {
 
             let (even, odd) = x.split_at_mut(n_half);
 
-            self.transform(even, n_half);
-            self.transform(odd, n_half);
+            Self::transform(even, n_half);
+            Self::transform(odd, n_half);
 
             let twiddle = fft_twiddle_factors(n);
 

--- a/symphonia-core/src/dsp/fft.rs
+++ b/symphonia-core/src/dsp/fft.rs
@@ -458,12 +458,7 @@ mod tests {
     /// Returns true if both real and imaginary complex number components deviate by less than
     /// `epsilon` between the left-hand side and right-hand side.
     fn check_complex(lhs: Complex, rhs: Complex, epsilon: f32) -> bool {
-        if (lhs.re - rhs.re).abs() < epsilon {
-            if (lhs.im - rhs.im).abs() < epsilon {
-                return true;
-            }
-        }
-        false
+        (lhs.re - rhs.re).abs() < epsilon && (lhs.im - rhs.im).abs() < epsilon
     }
 
     #[rustfmt::skip]

--- a/symphonia-core/src/dsp/mdct.rs
+++ b/symphonia-core/src/dsp/mdct.rs
@@ -164,15 +164,17 @@ mod tests {
 
         let pi_2n = f64::consts::PI / (2 * n_out) as f64;
 
-        for i in 0..n_out {
-            let mut accum = 0.0;
+        for (i, item) in y.iter_mut().enumerate().take(n_out) {
+            let accum: f64 = x
+                .iter()
+                .copied()
+                .map(f64::from)
+                .enumerate()
+                .take(n_in)
+                .map(|(j, jtem)| jtem * (pi_2n * ((2 * i + 1 + n_in) * (2 * j + 1)) as f64).cos())
+                .sum();
 
-            for j in 0..n_in {
-                let theta = pi_2n * ((2 * i + 1 + n_in) * (2 * j + 1)) as f64;
-                accum += f64::from(x[j]) * theta.cos();
-            }
-
-            y[i] = (scale * accum) as f32;
+            *item = (scale * accum) as f32;
         }
     }
 

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -331,7 +331,7 @@ pub mod util {
 
     /// A `SeekPoint` is a mapping between a sample or frame number to byte offset within a media
     /// stream.
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct SeekPoint {
         /// The frame or sample timestamp of the `SeekPoint`.
         pub frame_ts: u64,
@@ -361,7 +361,7 @@ pub mod util {
     /// `SeekSearchResult` is the return value for a search on a `SeekIndex`. It returns a range of
     /// `SeekPoint`s a `FormatReader` should search to find the desired timestamp. Ranges are
     /// lower-bound inclusive, and upper-bound exclusive.
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub enum SeekSearchResult {
         /// The `SeekIndex` is empty so the desired timestamp could not be found. The entire stream
         /// should be searched for the desired timestamp.

--- a/symphonia-core/src/io/bit.rs
+++ b/symphonia-core/src/io/bit.rs
@@ -1813,8 +1813,8 @@ mod tests {
             0x80,
         ];
 
-        const TEXT: &'static str = "This silence belongs to us... and every single person out \
-                                    there, is waiting for us to fill it with something.";
+        const TEXT: &str = "This silence belongs to us... and every single person out \
+                            there, is waiting for us to fill it with something.";
 
         // Reverse the bits in the data vector if testing a reverse bit-order.
         let data = match bit_order {

--- a/symphonia-core/src/io/bit.rs
+++ b/symphonia-core/src/io/bit.rs
@@ -1479,6 +1479,7 @@ mod tests {
     use super::{BitReaderRtl, ReadBitsRtl};
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn verify_bitstreamltr_ignore_bits() {
         let mut bs = BitReaderLtr::new(&[
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
@@ -1540,6 +1541,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn verify_bitstreamltr_read_bool() {
         // General tests.
         let mut bs = BitReaderLtr::new(&[0b1010_1010]);
@@ -1842,6 +1844,7 @@ mod tests {
     // BitStreamRtl
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn verify_bitstreamrtl_ignore_bits() {
         let mut bs = BitReaderRtl::new(&[
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
@@ -1903,6 +1906,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn verify_bitstreamrtl_read_bool() {
         // General tests.
         let mut bs = BitReaderRtl::new(&[0b1010_1010]);

--- a/symphonia-core/src/io/bit.rs
+++ b/symphonia-core/src/io/bit.rs
@@ -1818,7 +1818,7 @@ mod tests {
 
         // Reverse the bits in the data vector if testing a reverse bit-order.
         let data = match bit_order {
-            BitOrder::Verbatim => DATA.iter().map(|&b| b).collect(),
+            BitOrder::Verbatim => DATA.to_vec(),
             BitOrder::Reverse => DATA.iter().map(|&b| b.reverse_bits()).collect(),
         };
 

--- a/symphonia-core/src/meta.rs
+++ b/symphonia-core/src/meta.rs
@@ -69,7 +69,7 @@ pub struct MetadataOptions {
 ///
 /// The visual types listed here are derived from, though do not entirely cover, the ID3v2 APIC
 /// frame specification.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StandardVisualKey {
     FileIcon,
     OtherIcon,
@@ -95,7 +95,7 @@ pub enum StandardVisualKey {
 /// `StandardTagKey` is an enumeration providing standardized keys for common tag types.
 /// A tag reader may assign a `StandardTagKey` to a `Tag` if the tag's key is generally
 /// accepted to map to a specific usage.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StandardTagKey {
     AcoustidFingerprint,
     AcoustidId,

--- a/symphonia-core/src/units.rs
+++ b/symphonia-core/src/units.rs
@@ -123,7 +123,7 @@ impl From<f64> for Time {
 ///
 /// In other words, a `TimeBase` is the length in seconds of one tick of a `TimeStamp` or
 /// `Duration`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeBase {
     /// The numerator.
     pub numer: u32,

--- a/symphonia-core/src/util.rs
+++ b/symphonia-core/src/util.rs
@@ -278,10 +278,10 @@ pub mod clamp {
     #[inline]
     pub fn clamp_i24(val: i32) -> i32 {
         if val.wrapping_add(0x0080_0000) & !0x00ff_ffff == 0 {
-            val as i32
+            val
         }
         else {
-            0x007f_ffff ^ val.wrapping_shr(31) as i32
+            0x007f_ffff ^ val.wrapping_shr(31)
         }
     }
 

--- a/symphonia-format-isomp4/src/atoms/hdlr.rs
+++ b/symphonia-format-isomp4/src/atoms/hdlr.rs
@@ -16,7 +16,7 @@ use crate::{
 use log::warn;
 
 /// Handler type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum HandlerType {
     /// Video handler.
     Video,

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -399,7 +399,7 @@ fn add_media_type_tag<B: ReadBytes>(
 
     // There should only be 1 value.
     if let Some(value) = tag.values.first() {
-        if let Some(media_type_value) = value.data.get(0) {
+        if let Some(media_type_value) = value.data.first() {
             let media_type = match media_type_value {
                 0 => "Movie",
                 1 => "Normal",

--- a/symphonia-format-isomp4/src/atoms/mod.rs
+++ b/symphonia-format-isomp4/src/atoms/mod.rs
@@ -87,7 +87,7 @@ pub use udta::UdtaAtom;
 pub use wave::WaveAtom;
 
 /// Atom types.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AtomType {
     Ac3,
     AdvisoryTag,

--- a/symphonia-format-isomp4/src/atoms/trun.rs
+++ b/symphonia-format-isomp4/src/atoms/trun.rs
@@ -107,14 +107,12 @@ impl TrunAtom {
         if self.is_sample_size_present() {
             self.total_sample_size
         }
+        else if self.sample_count > 0 && self.is_first_sample_size_present() {
+            u64::from(self.sample_size[0])
+                + u64::from(self.sample_count - 1) * u64::from(default_size)
+        }
         else {
-            if self.sample_count > 0 && self.is_first_sample_size_present() {
-                u64::from(self.sample_size[0])
-                    + u64::from(self.sample_count - 1) * u64::from(default_size)
-            }
-            else {
-                u64::from(self.sample_count) * u64::from(default_size)
-            }
+            u64::from(self.sample_count) * u64::from(default_size)
         }
     }
 

--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -111,7 +111,7 @@ impl IsoMp4Reader {
 
             // Get the next timestamp for the next sample of the current track. The next sample may
             // be in a future segment.
-            for (seg_idx_delta, seg) in self.segs[state.cur_seg as usize..].iter().enumerate() {
+            for (seg_idx_delta, seg) in self.segs[state.cur_seg..].iter().enumerate() {
                 // Try to get the timestamp for the next sample of the track from the segment.
                 if let Some(timing) = seg.sample_timing(state.track_num, state.next_sample)? {
                     // Calculate the presentation time using the timestamp.
@@ -152,7 +152,7 @@ impl IsoMp4Reader {
 
     fn consume_next_sample(&mut self, info: &NextSampleInfo) -> Result<Option<SampleDataInfo>> {
         // Get the track state.
-        let track = &mut self.track_states[info.track_num as usize];
+        let track = &mut self.track_states[info.track_num];
 
         // Get the segment associated with the sample.
         let seg = &self.segs[info.seg_idx];
@@ -231,7 +231,7 @@ impl IsoMp4Reader {
 
     fn seek_track_by_time(&mut self, track_num: usize, time: Time) -> Result<SeekedTo> {
         // Convert time to timestamp for the track.
-        if let Some(track) = self.tracks.get(track_num as usize) {
+        if let Some(track) = self.tracks.get(track_num) {
             let tb = track.codec_params.time_base.unwrap();
             self.seek_track_by_ts(track_num, tb.calc_timestamp(time))
         }
@@ -280,7 +280,7 @@ impl IsoMp4Reader {
             let data_desc = seg.sample_data(track_num, seek_loc.sample_num, true)?;
 
             // Update the track's next sample information to point to the seeked sample.
-            let track = &mut self.track_states[track_num as usize];
+            let track = &mut self.track_states[track_num];
 
             track.cur_seg = seek_loc.seg_idx;
             track.next_sample = seek_loc.sample_num;

--- a/symphonia-format-isomp4/src/stream.rs
+++ b/symphonia-format-isomp4/src/stream.rs
@@ -90,10 +90,11 @@ impl MoofSegment {
 
         // Calculate the sequence information for each track, even if not present in the fragment.
         for (track_num, trex) in mvex.trexs.iter().enumerate() {
-            let mut info: SequenceInfo = Default::default();
-
-            info.first_sample = prev.track_sample_range(track_num).end;
-            info.first_ts = prev.track_ts_range(track_num).end;
+            let mut info = SequenceInfo {
+                first_sample: prev.track_sample_range(track_num).end,
+                first_ts: prev.track_ts_range(track_num).end,
+                ..Default::default()
+            };
 
             // Find the track fragment for the track.
             for (traf_idx, traf) in moof.trafs.iter().enumerate() {

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -95,7 +95,7 @@ fn vorbis_extra_data_from_codec_private(extra: &[u8]) -> Result<Box<[u8]>> {
     let mut setup_header = None;
 
     for packet in packets {
-        match packet.get(0).copied() {
+        match packet.first().copied() {
             Some(VORBIS_PACKET_TYPE_IDENTIFICATION) => {
                 ident_header = Some(packet);
             }

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -568,7 +568,7 @@ impl FormatReader for MkvReader {
         loop {
             if let Some(frame) = self.frames.pop_front() {
                 return Ok(Packet::new_from_boxed_slice(
-                    frame.track as u32,
+                    frame.track,
                     frame.timestamp,
                     frame.duration,
                     frame.data,

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -72,7 +72,7 @@ pub(crate) fn read_unsigned_vint<R: ReadBytes>(reader: R) -> Result<u64> {
 pub(crate) fn read_signed_vint<R: ReadBytes>(mut reader: R) -> Result<i64> {
     let (value, len) = read_vint(&mut reader)?;
     // Convert to a signed integer by range shifting.
-    let half_range = i64::pow(2, (len * 7) as u32 - 1) - 1;
+    let half_range = i64::pow(2, (len * 7) - 1) - 1;
     Ok(value as i64 - half_range)
 }
 

--- a/symphonia-format-mkv/src/lacing.rs
+++ b/symphonia-format-mkv/src/lacing.rs
@@ -49,7 +49,7 @@ fn read_ebml_sizes<R: ReadBytes>(mut reader: R, frames: usize) -> Result<Vec<u64
 pub(crate) fn read_xiph_sizes<R: ReadBytes>(mut reader: R, frames: usize) -> Result<Vec<u64>> {
     let mut prefixes = 0;
     let mut sizes = Vec::new();
-    while sizes.len() < frames as usize {
+    while sizes.len() < frames {
         let byte = reader.read_byte()? as u64;
         if byte == 255 {
             prefixes += 1;

--- a/symphonia-format-ogg/src/mappings/vorbis.rs
+++ b/symphonia-format-ogg/src/mappings/vorbis.rs
@@ -574,7 +574,7 @@ fn skip_residue_setup(bs: &mut BitReaderRtl<'_>) -> Result<()> {
     let residue_classifications = bs.read_bits_leq32(6)? as u8 + 1;
 
     // residue_classbook
-    let _ = bs.ignore_bits(8)?;
+    bs.ignore_bits(8)?;
 
     let mut num_codebooks = 0;
 

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -383,7 +383,7 @@ fn play_track(
     };
 
     if !no_progress {
-        println!("");
+        println!();
     }
 
     // Return if a fatal error occured.

--- a/symphonia-utils-xiph/src/flac/metadata.rs
+++ b/symphonia-utils-xiph/src/flac/metadata.rs
@@ -412,7 +412,7 @@ pub fn read_application_block<B: ReadBytes>(
     // string.
     let ident_buf = reader.read_quad_bytes()?;
     let ident = String::from_utf8(
-        ident_buf.as_ref().iter().map(|b| ascii::escape_default(*b)).flatten().collect(),
+        ident_buf.as_ref().iter().copied().flat_map(ascii::escape_default).collect(),
     )
     .unwrap();
 

--- a/symphonia-utils-xiph/src/flac/metadata.rs
+++ b/symphonia-utils-xiph/src/flac/metadata.rs
@@ -503,7 +503,7 @@ impl MetadataBlockHeader {
         let is_last = (header_enc & 0x80) == 0x80;
 
         // The next 7 bits of the header indicates the block type.
-        let block_type_id = (header_enc & 0x7f) as u8;
+        let block_type_id = header_enc & 0x7f;
 
         let block_type = match block_type_id {
             0 => MetadataBlockType::StreamInfo,

--- a/symphonia-utils-xiph/src/flac/metadata.rs
+++ b/symphonia-utils-xiph/src/flac/metadata.rs
@@ -18,7 +18,7 @@ use symphonia_core::meta::{VendorData, Visual};
 
 use symphonia_metadata::{id3v2, vorbis};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum MetadataBlockType {
     StreamInfo,
     Padding,

--- a/symphonia/examples/getting-started.rs
+++ b/symphonia/examples/getting-started.rs
@@ -11,7 +11,7 @@ fn main() {
     let path = args.get(1).expect("file path not provided");
 
     // Open the media source.
-    let src = std::fs::File::open(&path).expect("failed to open media");
+    let src = std::fs::File::open(path).expect("failed to open media");
 
     // Create the media source stream.
     let mss = MediaSourceStream::new(Box::new(src), Default::default());


### PR DESCRIPTION
This fixes existing clippy warnings, with a lot of them triggered by test code.

I guess clippy wasn't run before to find these test warnings, and then the existing warnings were hidden for users like me using rust-analyzer