### PR TITLE
core: Add `SampleBuffer::samples_mut`

### DIFF
--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -733,6 +733,11 @@ impl<S: Sample> SampleBuffer<S> {
         &self.buf[..self.n_written]
     }
 
+    /// Gets a mutable slice of all written samples.
+    pub fn samples_mut(&mut self) -> &mut [S] {
+        &mut self.buf[..self.n_written]
+    }
+
     /// Gets the maximum number of samples the `SampleBuffer` may store.
     pub fn capacity(&self) -> usize {
         self.buf.len()


### PR DESCRIPTION
Allows mutable access to exported samples, enabling in-place processing of output audio data.

Currently, to use functions like libopus's soft_clip (which take `&mut [f32]`, interleaved) this can only be achieved on `SampleBuffer` with a significant memcopy (seemingly ~8us for 1920 `f32` samples, relative to ~40us decode + ~80us encode). `samples_mut` removes this additional overhead.