### PR TITLE
Don't preallocate a full vector, allocate on demand

### DIFF
--- a/symphonia-metadata/src/vorbis.rs
+++ b/symphonia-metadata/src/vorbis.rs
@@ -150,8 +150,8 @@ pub fn read_comment_no_framing<B: ReadBytes>(
         let comment_length = reader.read_u32()?;
 
         // Read the comment string.
-        let mut comment_byte = vec![0; comment_length as usize];
-        reader.read_buf_exact(&mut comment_byte)?;
+        let mut comment_byte = Vec::new();
+        reader.read_bytes_exact(comment_length as usize, &mut comment_byte)?;
 
         // Parse the comment string into a Tag and insert it into the parsed tag list.
         metadata.add_tag(parse(&String::from_utf8_lossy(&comment_byte)));

--- a/symphonia-utils-xiph/src/flac/metadata.rs
+++ b/symphonia-utils-xiph/src/flac/metadata.rs
@@ -426,8 +426,8 @@ pub fn read_picture_block<B: ReadBytes>(
     let media_type_len = reader.read_be_u32()? as usize;
 
     // Read the Media Type bytes
-    let mut media_type_buf = vec![0u8; media_type_len];
-    reader.read_buf_exact(&mut media_type_buf)?;
+    let mut media_type_buf = Vec::new();
+    reader.read_bytes_exact(media_type_len, &mut media_type_buf)?;
 
     // Convert Media Type bytes to an ASCII string. Non-printable ASCII characters are invalid.
     let media_type = match printable_ascii_to_string(&media_type_buf) {
@@ -439,8 +439,8 @@ pub fn read_picture_block<B: ReadBytes>(
     let desc_len = reader.read_be_u32()? as usize;
 
     // Read the description bytes.
-    let mut desc_buf = vec![0u8; desc_len];
-    reader.read_buf_exact(&mut desc_buf)?;
+    let mut desc_buf = Vec::new();
+    reader.read_bytes_exact(desc_len, &mut desc_buf)?;
 
     let desc = String::from_utf8_lossy(&desc_buf);
 


### PR DESCRIPTION
This avoids OOM issues, at the cost of resizing a bit more.

I originally had a design where streams could say how long they are, but I figured just letting vec resize here is the best solution.

I looked through for any other places where `vec![expr; length]` is called where `length` is untrusted, and did only see these. If there's any more I'll fix em.

Sorry, no test files for this, I kinda did the work a while ago and forgot I did it, so didn't keep any test files.