### PR TITLE
meta: use unsyncedlyrics vorbis tag for lyrics

### DIFF
--- a/symphonia-metadata/src/vorbis.rs
+++ b/symphonia-metadata/src/vorbis.rs
@@ -100,6 +100,7 @@ lazy_static! {
         m.insert("totaltracks"                 , StandardTagKey::TrackTotal);
         m.insert("tracknumber"                 , StandardTagKey::TrackNumber);
         m.insert("tracktotal"                  , StandardTagKey::TrackTotal);
+        m.insert("unsyncedlyrics"              , StandardTagKey::Lyrics);
         m.insert("upc"                         , StandardTagKey::IdentUpc);
         m.insert("version"                     , StandardTagKey::Remixer);
         m.insert("version"                     , StandardTagKey::Version);


### PR DESCRIPTION
Some .flac files downloaded from Bandcamp have the `UNSYNCEDLYRICS` tag set if the artist added lyrics to a track.  This PR enables Symphonia to also read this tag for lyrics metadata.