### PR TITLE
Handle incorrect channel mask in WAV files

### DIFF
--- a/symphonia-format-wav/src/chunks.rs
+++ b/symphonia-format-wav/src/chunks.rs
@@ -41,6 +41,10 @@ impl ParseChunkTag for NullChunks {
 fn fix_channel_mask(mut channel_mask: u32, n_channels: u16) -> u32 {
     let channel_diff = n_channels as i32 - channel_mask.count_ones() as i32;
 
+    if channel_diff != 0 {
+        info!("Channel mask not set correctly, channel positions may be incorrect!");
+    }
+
     // Check that the number of ones in the channel mask match the number of channels.
     if channel_diff > 0 {
         // Too few ones in mask so add extra ones above the most significant one

--- a/symphonia-format-wav/src/chunks.rs
+++ b/symphonia-format-wav/src/chunks.rs
@@ -394,7 +394,12 @@ impl WaveFormatChunk {
             );
         }
 
-        let channel_mask = reader.read_u32()?;
+        let mut channel_mask = reader.read_u32()?;
+
+        // Graceful handling of "empty" channel mask value. Use the first n_channels channels.
+        if channel_mask == 0 {
+            channel_mask = (1 << n_channels) - 1;
+        }
 
         // The number of ones in the channel mask should match the number of channels.
         if channel_mask.count_ones() != u32::from(n_channels) {


### PR DESCRIPTION
This PR contains a work around for some WAV files that have an incorrect channel mask value. For example VLC can still play them.