### PR TITLE
core: Clean up Debug formatting of meta::Visual

### DIFF
--- a/symphonia-core/src/meta.rs
+++ b/symphonia-core/src/meta.rs
@@ -352,7 +352,7 @@ pub enum ColorMode {
 }
 
 /// A `Visual` is any 2 dimensional graphic.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Visual {
     /// The Media Type (MIME Type) used to encode the `Visual`.
     pub media_type: String,
@@ -377,6 +377,20 @@ pub struct Visual {
     pub tags: Vec<Tag>,
     /// The data of the `Visual`, encoded as per `media_type`.
     pub data: Box<[u8]>,
+}
+
+impl fmt::Debug for Visual {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Visual")
+            .field("media_type", &self.media_type)
+            .field("dimensions", &self.dimensions)
+            .field("bits_per_pixel", &self.bits_per_pixel)
+            .field("color_mode", &self.color_mode)
+            .field("usage", &self.usage)
+            .field("tags", &self.tags)
+            .field("data", &format_args!("[u8; {}]", self.data.len()))
+            .finish()
+    }
 }
 
 /// `VendorData` is any binary metadata that is proprietary to a certain application or vendor.


### PR DESCRIPTION
This removes the often large and unreadable Debug formatting for the affected type (a raw `[u8]` dump for an embedded image file), and replaces the output for data with a manually-formatted type that only shows the data's size. An alternative would be using a wrapper type for `Box<u8>` that implements this manual debug format on its own, avoiding the possible maintenance burden this PR could have and being reusable for other blob-like data in Symphonia, but this was not chosen as it would likely become a breaking change for relatively little benefit.