### PR TITLE
Make StandardTag{Key,Visual} implement Hash

### DIFF
--- a/symphonia-core/src/meta.rs
+++ b/symphonia-core/src/meta.rs
@@ -69,7 +69,7 @@ pub struct MetadataOptions {
 ///
 /// The visual types listed here are derived from, though do not entirely cover, the ID3v2 APIC
 /// frame specification.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StandardVisualKey {
     FileIcon,
     OtherIcon,
@@ -95,7 +95,7 @@ pub enum StandardVisualKey {
 /// `StandardTagKey` is an enumeration providing standardized keys for common tag types.
 /// A tag reader may assign a `StandardTagKey` to a `Tag` if the tag's key is generally
 /// accepted to map to a specific usage.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StandardTagKey {
     AcoustidFingerprint,
     AcoustidId,
@@ -483,8 +483,7 @@ impl<'a> Metadata<'a> {
     pub fn pop(&mut self) -> Option<MetadataRevision> {
         if self.revisions.len() > 1 {
             self.revisions.pop_front()
-        }
-        else {
+        } else {
             None
         }
     }


### PR DESCRIPTION
This would come very handy when trying to get the value of a standard tag or visual multiple times, allowing for instance to build a `HashMap<StandardTagKey, Value>` and fetching from it instead of having to rely on a `&[Tag]` which requires iteration for each search.