### PR TITLE
Reduce logging verbosity

### DIFF
--- a/symphonia-bundle-flac/src/demuxer.rs
+++ b/symphonia-bundle-flac/src/demuxer.rs
@@ -19,7 +19,7 @@ use symphonia_core::probe::{Descriptor, Instantiate, QueryDescriptor};
 
 use symphonia_utils_xiph::flac::metadata::*;
 
-use log::{debug, info};
+use log::{debug, trace};
 
 use super::parser::PacketParser;
 
@@ -69,8 +69,7 @@ impl FlacReader {
                         let mut new_index = SeekIndex::new();
                         read_seek_table_block(&mut block_stream, header.block_len, &mut new_index)?;
                         index = Some(new_index);
-                    }
-                    else {
+                    } else {
                         return decode_error("flac: found more than one seek table block");
                     }
                 }
@@ -98,7 +97,7 @@ impl FlacReader {
                 // version of FLAC, but  print a message.
                 MetadataBlockType::Unknown(id) => {
                     block_stream.ignore_bytes(u64::from(header.block_len))?;
-                    info!("ignoring {} bytes of block width id={}.", header.block_len, id);
+                    trace!("ignoring {} bytes of block width id={}.", header.block_len, id);
                 }
             }
 
@@ -107,7 +106,7 @@ impl FlacReader {
             let block_unread_len = block_stream.bytes_available();
 
             if block_unread_len > 0 {
-                info!("under read block by {} bytes.", block_unread_len);
+                trace!("under read block by {} bytes.", block_unread_len);
                 block_stream.ignore_bytes(block_unread_len)?;
             }
 
@@ -204,8 +203,7 @@ impl FormatReader for FlacReader {
                 // known, the seek cannot be completed.
                 if let Some(sample_rate) = params.sample_rate {
                     TimeBase::new(1, sample_rate).calc_timestamp(time)
-                }
-                else {
+                } else {
                     return seek_error(SeekErrorKind::Unseekable);
                 }
             }
@@ -265,13 +263,11 @@ impl FormatReader for FlacReader {
 
                 if ts < sync.ts {
                     end_byte_offset = mid_byte_offset;
-                }
-                else if ts > sync.ts && ts < sync.ts + sync.dur {
+                } else if ts > sync.ts && ts < sync.ts + sync.dur {
                     debug!("seeked to ts={} (delta={})", sync.ts, sync.ts as i64 - ts as i64);
 
                     return Ok(SeekedTo { track_id: 0, actual_ts: sync.ts, required_ts: ts });
-                }
-                else {
+                } else {
                     start_byte_offset = mid_byte_offset;
                 }
             }
@@ -366,8 +362,7 @@ fn read_stream_info_block<B: ReadBytes + FiniteStream>(
 
         // Add the track.
         tracks.push(Track::new(0, codec_params));
-    }
-    else {
+    } else {
         return decode_error("flac: found more than one stream info block");
     }
 

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -20,7 +20,7 @@ use crate::header::{self, MAX_MPEG_FRAME_SIZE, MPEG_HEADER_LEN};
 
 use std::io::{Seek, SeekFrom};
 
-use log::{debug, info, warn};
+use log::{debug, trace, warn};
 
 /// MPEG1 and MPEG2 audio elementary stream reader.
 ///
@@ -112,42 +112,38 @@ impl FormatReader for MpaReader {
                 params.with_delay(lame_tag.enc_delay).with_padding(lame_tag.enc_padding);
 
                 (lame_tag.enc_delay, lame_tag.enc_padding)
-            }
-            else {
+            } else {
                 (0, 0)
             };
 
             // The base Xing/Info tag may contain the number of frames.
             if let Some(num_mpeg_frames) = info_tag.num_frames {
-                info!("using xing header for duration");
+                trace!("using xing header for duration");
 
                 let num_frames = u64::from(num_mpeg_frames) * header.duration();
 
                 // Adjust for gapless playback.
                 if options.enable_gapless {
                     params.with_n_frames(num_frames - u64::from(delay) - u64::from(padding));
-                }
-                else {
+                } else {
                     params.with_n_frames(num_frames);
                 }
             }
-        }
-        else if let Some(vbri_tag) = try_read_vbri_tag(&packet, &header) {
-            info!("using vbri header for duration");
+        } else if let Some(vbri_tag) = try_read_vbri_tag(&packet, &header) {
+            trace!("using vbri header for duration");
 
             let num_frames = u64::from(vbri_tag.num_mpeg_frames) * header.duration();
 
             // Check if there is a VBRI tag.
             params.with_n_frames(num_frames);
-        }
-        else {
+        } else {
             // The first frame was not a Xing/Info header, rewind back to the start of the frame so
             // that it may be decoded.
             source.seek_buffered_rev(MPEG_HEADER_LEN + header.frame_size);
 
             // Likely not a VBR file, so estimate the duration if seekable.
             if source.is_seekable() {
-                info!("estimating duration from bitrate, may be inaccurate for vbr files");
+                trace!("estimating duration from bitrate, may be inaccurate for vbr files");
 
                 if let Some(n_mpeg_frames) = estimate_num_mpeg_frames(&mut source) {
                     params.with_n_frames(n_mpeg_frames * header.duration());
@@ -180,8 +176,7 @@ impl FormatReader for MpaReader {
                     warn!("found an unexpected xing tag, discarding");
                     continue;
                 }
-            }
-            else if is_maybe_vbri_tag(&packet, &header)
+            } else if is_maybe_vbri_tag(&packet, &header)
                 && try_read_vbri_tag(&packet, &header).is_some()
             {
                 // Discard the packet and tag since it was not at the start of the stream.
@@ -237,8 +232,7 @@ impl FormatReader for MpaReader {
                 // known, the seek cannot be completed.
                 if let Some(sample_rate) = self.tracks[0].codec_params.sample_rate {
                     TimeBase::new(1, sample_rate).calc_timestamp(time)
-                }
-                else {
+                } else {
                     return seek_error(SeekErrorKind::Unseekable);
                 }
             }
@@ -247,8 +241,7 @@ impl FormatReader for MpaReader {
         // If gapless playback is enabled, get the delay.
         let delay = if self.options.enable_gapless {
             u64::from(self.tracks[0].codec_params.delay.unwrap_or(0))
-        }
-        else {
+        } else {
             0
         };
 
@@ -388,8 +381,7 @@ impl MpaReader {
         // If gapless playback is enabled, get the padding.
         let padding = if self.options.enable_gapless {
             u64::from(self.tracks[0].codec_params.padding.unwrap_or(0))
-        }
-        else {
+        } else {
             0
         };
 
@@ -680,8 +672,7 @@ fn try_read_info_tag_inner(buf: &[u8], header: &FrameHeader) -> Result<Option<Xi
         let mut toc = [0; 100];
         reader.read_buf_exact(&mut toc)?;
         Some(toc)
-    }
-    else {
+    } else {
         None
     };
 
@@ -731,8 +722,7 @@ fn try_read_info_tag_inner(buf: &[u8], header: &FrameHeader) -> Result<Option<Xi
                 let padding = trim & ((1 << 12) - 1);
 
                 (delay, padding.saturating_sub(528 + 1))
-            }
-            else {
+            } else {
                 (0, 0)
             }
         };
@@ -760,15 +750,13 @@ fn try_read_info_tag_inner(buf: &[u8], header: &FrameHeader) -> Result<Option<Xi
             if header.has_crc || encoder[..4] == *b"LAME" {
                 // Read the CRC using the inner reader to not change the computed CRC.
                 Some(reader.inner_mut().read_be_u16()?)
-            }
-            else {
+            } else {
                 // No CRC is present.
                 None
             }
-        }
-        else {
+        } else {
             // The tag is truncated. No CRC will be present.
-            info!("xing tag lame extension is truncated");
+            trace!("xing tag lame extension is truncated");
             None
         };
 
@@ -785,16 +773,14 @@ fn try_read_info_tag_inner(buf: &[u8], header: &FrameHeader) -> Result<Option<Xi
                 enc_delay,
                 enc_padding,
             })
-        }
-        else {
+        } else {
             // The CRC did not match, this is probably not a LAME tag.
             warn!("xing tag lame extension crc mismatch");
             None
         }
-    }
-    else {
+    } else {
         // Frame not large enough for a LAME tag.
-        info!("xing tag too small for lame extension");
+        trace!("xing tag too small for lame extension");
         None
     };
 
@@ -808,8 +794,7 @@ fn parse_lame_tag_replaygain(value: u16, expected_name: u8) -> Option<f32> {
     if name == expected_name {
         let gain = (value & 0x01ff) as f32 / 10.0;
         Some(if value & 0x200 != 0 { -gain } else { gain })
-    }
-    else {
+    } else {
         None
     }
 }

--- a/symphonia-bundle-mp3/src/layer3/requantize.rs
+++ b/symphonia-bundle-mp3/src/layer3/requantize.rs
@@ -17,7 +17,7 @@ use std::{f32, f64};
 
 use lazy_static::lazy_static;
 
-use log::info;
+use log::trace;
 
 lazy_static! {
     /// Lookup table for computing x(i) = s(i)^(4/3) where s(i) is a decoded Huffman sample. The
@@ -131,8 +131,7 @@ pub(super) fn read_huffman_samples<B: ReadBitsLtr>(
                 // negative. The value of the sample is raised to the (4/3) power.
                 buf[i] = (1.0 - 2.0 * bs.read_bit()? as f32) * pow43_table[x];
                 bits_read += 1;
-            }
-            else {
+            } else {
                 buf[i] = 0.0;
             }
 
@@ -147,8 +146,7 @@ pub(super) fn read_huffman_samples<B: ReadBitsLtr>(
 
                 buf[i] = (1.0 - 2.0 * bs.read_bit()? as f32) * pow43_table[y];
                 bits_read += 1;
-            }
-            else {
+            } else {
                 buf[i] = 0.0;
             }
 
@@ -183,31 +181,27 @@ pub(super) fn read_huffman_samples<B: ReadBitsLtr>(
         if value & 0x1 != 0 {
             buf[i + 3] = 1.0 - 2.0 * (signs & 1) as f32;
             signs >>= 1;
-        }
-        else {
+        } else {
             buf[i + 3] = 0.0;
         }
 
         if value & 0x2 != 0 {
             buf[i + 2] = 1.0 - 2.0 * (signs & 1) as f32;
             signs >>= 1;
-        }
-        else {
+        } else {
             buf[i + 2] = 0.0;
         }
 
         if value & 0x4 != 0 {
             buf[i + 1] = 1.0 - 2.0 * (signs & 1) as f32;
             signs >>= 1;
-        }
-        else {
+        } else {
             buf[i + 1] = 0.0;
         }
 
         if value & 0x8 != 0 {
             buf[i + 0] = 1.0 - 2.0 * (signs & 1) as f32;
-        }
-        else {
+        } else {
             buf[i + 0] = 0.0;
         }
 
@@ -224,13 +218,12 @@ pub(super) fn read_huffman_samples<B: ReadBitsLtr>(
     // samples, therefore, undo them! The caller will be reponsible for re-aligning the bitstream
     // reader. Candy Pop confirms this.
     else if bits_read > part3_bits && i > big_values_len {
-        info!("count1 overrun, malformed bitstream");
+        trace!("count1 overrun, malformed bitstream");
         i -= 4;
-    }
-    else if bits_read > part3_bits {
+    } else if bits_read > part3_bits {
         // It seems that most other decoders don't undo overruns of the big values. We'll just print
         // a message for now.
-        info!("big_values overrun, malformed bitstream");
+        trace!("big_values overrun, malformed bitstream");
     }
 
     // The final partition after the count1 partition is the rzero partition. Samples in this

--- a/symphonia-check/src/main.rs
+++ b/symphonia-check/src/main.rs
@@ -25,7 +25,7 @@ use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
 use clap::Arg;
-use log::{info, warn};
+use log::{trace, warn};
 
 /// The absolute maximum allowable sample delta. Around 2^-17 (-102.4dB).
 const ABS_MAX_ALLOWABLE_SAMPLE_DELTA: f32 = 0.00001;
@@ -193,7 +193,7 @@ fn copy_audio_buf_to_sample_buf(src: AudioBufferRef<'_>, dst: &mut Option<Sample
         let spec = *src.spec();
         let duration = src.capacity() as u64;
 
-        info!(
+        trace!(
             "created target raw audio buffer with rate={}, channels={}, duration={}",
             spec.rate,
             spec.channels.count(),
@@ -226,8 +226,7 @@ fn run_check(
         // Decode target's next audio buffer.
         if opts.keep_going {
             get_next_audio_buf_best_effort(tgt_inst)?;
-        }
-        else {
+        } else {
             get_next_audio_buf(tgt_inst)?;
         }
 
@@ -420,8 +419,7 @@ fn main() {
     let ret = if res.n_failed_samples == 0 {
         println!("PASS");
         0
-    }
-    else {
+    } else {
         println!("FAIL");
         1
     };

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -13,7 +13,7 @@ use crate::formats::{FormatOptions, FormatReader};
 use crate::io::{MediaSourceStream, ReadBytes, SeekBuffered};
 use crate::meta::{Metadata, MetadataLog, MetadataOptions, MetadataReader};
 
-use log::{debug, error, info};
+use log::{debug, error, trace};
 
 mod bloom {
 
@@ -272,7 +272,7 @@ impl Probe {
 
                             // TODO: Implement scoring.
 
-                            info!(
+                            trace!(
                                 "found the format marker {:x?} @ {}+{} bytes.",
                                 &context[0..len],
                                 init_pos,

--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -22,7 +22,7 @@ use crate::atoms::{AtomIterator, AtomType};
 use crate::atoms::{FtypAtom, MetaAtom, MoofAtom, MoovAtom, MvexAtom, SidxAtom, TrakAtom};
 use crate::stream::*;
 
-use log::{debug, info, trace, warn};
+use log::{debug, trace, warn};
 
 pub struct TrackState {
     codec_params: CodecParameters,
@@ -166,8 +166,7 @@ impl IsoMp4Reader {
         // then the base position is the position of current the sample.
         let pos = if sample_data_desc.base_pos > track.next_sample_pos {
             sample_data_desc.base_pos
-        }
-        else {
+        } else {
             track.next_sample_pos
         };
 
@@ -212,8 +211,7 @@ impl IsoMp4Reader {
 
                         // Push the segment.
                         self.segs.push(Box::new(seg));
-                    }
-                    else {
+                    } else {
                         // TODO: This is a fatal error.
                         return decode_error("isomp4: moof atom present without mvex atom");
                     }
@@ -234,8 +232,7 @@ impl IsoMp4Reader {
         if let Some(track) = self.tracks.get(track_num) {
             let tb = track.codec_params.time_base.unwrap();
             self.seek_track_by_ts(track_num, tb.calc_timestamp(time))
-        }
-        else {
+        } else {
             seek_error(SeekErrorKind::Unseekable)
         }
     }
@@ -297,8 +294,7 @@ impl IsoMp4Reader {
             );
 
             Ok(SeekedTo { track_id: track_num as u32, required_ts: ts, actual_ts: timing.ts })
-        }
-        else {
+        } else {
             // Timestamp was not found.
             seek_error(SeekErrorKind::OutOfRange)
         }
@@ -337,10 +333,9 @@ impl FormatReader for IsoMp4Reader {
             let pos = mss.pos();
             let len = mss.seek(SeekFrom::End(0))?;
             mss.seek(SeekFrom::Start(pos))?;
-            info!("stream is seekable with len={} bytes.", len);
+            trace!("stream is seekable with len={} bytes.", len);
             Some(len)
-        }
-        else {
+        } else {
             None
         };
 
@@ -365,8 +360,7 @@ impl FormatReader for IsoMp4Reader {
                     if !is_seekable {
                         sidx = Some(iter.read_atom::<SidxAtom>()?);
                         break;
-                    }
-                    else {
+                    } else {
                         // If the stream is seekable, examine all segment indexes and select the
                         // index with the earliest presentation timestamp to be the first.
                         let new_sidx = iter.read_atom::<SidxAtom>()?;
@@ -407,7 +401,7 @@ impl FormatReader for IsoMp4Reader {
                 AtomType::Free => (),
                 AtomType::Skip => (),
                 _ => {
-                    info!("skipping top-level atom: {:?}.", header.atype);
+                    trace!("skipping top-level atom: {:?}.", header.atype);
                 }
             }
         }
@@ -443,10 +437,9 @@ impl FormatReader for IsoMp4Reader {
         if moov.is_fragmented() {
             // If a Segment Index (sidx) atom was found, add the segments contained within.
             if sidx.is_some() {
-                info!("stream is segmented with a segment index.");
-            }
-            else {
-                info!("stream is segmented without a segment index.");
+                trace!("stream is segmented with a segment index.");
+            } else {
+                trace!("stream is segmented without a segment index.");
             }
         }
 
@@ -498,8 +491,7 @@ impl FormatReader for IsoMp4Reader {
             // Using the current set of segments, try to get the next sample info.
             if let Some(info) = self.next_sample_info()? {
                 break info;
-            }
-            else {
+            } else {
                 // No more segments. If the stream is unseekable, it may be the case that there are
                 // more segments coming. Iterate atoms until a new segment is found or the
                 // end-of-stream is reached.
@@ -517,14 +509,12 @@ impl FormatReader for IsoMp4Reader {
             if reader.is_seekable() {
                 // Fallback to a slow seek if the stream is seekable.
                 reader.seek(SeekFrom::Start(sample_info.pos))?;
-            }
-            else if sample_info.pos > reader.pos() {
+            } else if sample_info.pos > reader.pos() {
                 // The stream is not seekable but the desired seek position is ahead of the reader's
                 // current position, thus the seek can be emulated by ignoring the bytes up to the
                 // the desired seek position.
                 reader.ignore_bytes(sample_info.pos - reader.pos())?;
-            }
-            else {
+            } else {
                 // The stream is not seekable and the desired seek position falls outside the lower
                 // bound of the buffer cache. This sample cannot be read.
                 return decode_error("isomp4: packet out-of-bounds for a non-seekable stream");
@@ -576,8 +566,7 @@ impl FormatReader for IsoMp4Reader {
 
                     // Seek the primary track and return the result.
                     self.seek_track_by_ts(selected_track_id, ts)
-                }
-                else {
+                } else {
                     seek_error(SeekErrorKind::Unseekable)
                 }
             }

--- a/symphonia-format-mkv/src/codecs.rs
+++ b/symphonia-format-mkv/src/codecs.rs
@@ -41,7 +41,7 @@ pub(crate) fn codec_id_to_type(track: &TrackElement) -> Option<CodecType> {
             _ => None,
         },
         _ => {
-            log::info!("unknown codec: {}", &track.codec_id);
+            log::trace!("unknown codec: {}", &track.codec_id);
             None
         }
     }

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -144,8 +144,7 @@ impl MkvReader {
             while let Some(frame) = self.frames.front() {
                 if frame.timestamp + frame.duration >= ts && frame.track == track_id {
                     break 'out frame.timestamp;
-                }
-                else {
+                } else {
                     self.frames.pop_front();
                 }
             }
@@ -158,8 +157,7 @@ impl MkvReader {
     fn seek_track_by_ts(&mut self, track_id: u32, ts: u64) -> Result<SeekedTo> {
         if self.clusters.is_empty() {
             self.seek_track_by_ts_forward(track_id, ts)
-        }
-        else {
+        } else {
             let mut target_cluster = None;
             for cluster in &self.clusters {
                 if cluster.timestamp > ts {
@@ -309,10 +307,9 @@ impl FormatReader for MkvReader {
             let pos = reader.pos();
             let len = reader.seek(SeekFrom::End(0))?;
             reader.seek(SeekFrom::Start(pos))?;
-            log::info!("stream is seekable with len={} bytes.", len);
+            log::trace!("stream is seekable with len={} bytes.", len);
             Some(len)
-        }
-        else {
+        } else {
             None
         };
 

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -46,7 +46,7 @@ pub(crate) fn read_tag<R: ReadBytes>(mut reader: R) -> Result<(u32, u32, bool)> 
         let ty = ELEMENTS.get(&tag).map(|(_, ty)| ty).filter(|ty| ty.is_top_level());
 
         if let Some(ty) = ty {
-            log::info!("found next supported tag {:08X} ({:?})", tag, ty);
+            log::trace!("found next supported tag {:08X} ({:?})", tag, ty);
             return Ok((tag, 4, true));
         }
         tag = (tag << 8) | u32::from(reader.read_u8()?);
@@ -172,8 +172,7 @@ impl ElementHeader {
     pub(crate) fn end(&self) -> Option<u64> {
         if self.data_len == 0 {
             None
-        }
-        else {
+        } else {
             Some(self.data_pos + self.data_len)
         }
     }
@@ -259,11 +258,9 @@ impl<R: ReadBytes> ElementIterator<R> {
         self.current = None;
         if self.reader.is_seekable() {
             self.reader.seek(SeekFrom::Start(pos))?;
-        }
-        else if pos < current_pos {
+        } else if pos < current_pos {
             return seek_error(SeekErrorKind::ForwardOnly);
-        }
-        else {
+        } else {
             self.reader.ignore_bytes(pos - current_pos)?;
         }
         self.next_pos = pos;

--- a/symphonia-format-ogg/src/demuxer.rs
+++ b/symphonia-format-ogg/src/demuxer.rs
@@ -16,7 +16,7 @@ use symphonia_core::meta::{Metadata, MetadataLog};
 use symphonia_core::probe::{Descriptor, Instantiate, QueryDescriptor};
 use symphonia_core::support_format;
 
-use log::{debug, info, warn};
+use log::{debug, trace, warn};
 
 use super::common::SideData;
 use super::logical::LogicalStream;
@@ -67,8 +67,7 @@ impl OggReader {
         if let Some(stream) = self.streams.get_mut(&page.header.serial) {
             // TODO: Process side data.
             let _side_data = stream.read_page(&page)?;
-        }
-        else {
+        } else {
             // If there is no associated logical stream with this page, then this is a
             // completely random page within the physical stream. Discard it.
         }
@@ -81,8 +80,7 @@ impl OggReader {
 
         if let Some(stream) = self.streams.get(&page.header.serial) {
             stream.peek_packet()
-        }
-        else {
+        } else {
             None
         }
     }
@@ -150,13 +148,11 @@ impl OggReader {
                     // The required timestamp is less-than the timestamp of the first sample in
                     // page1. Update the upper bound and bisect again.
                     end_byte_pos = mid_byte_pos;
-                }
-                else if required_ts > end_ts {
+                } else if required_ts > end_ts {
                     // The required timestamp is greater-than the timestamp of the final sample in
                     // the in page1. Update the lower bound and bisect again.
                     start_byte_pos = mid_byte_pos;
-                }
-                else {
+                } else {
                     // The sample with the required timestamp is contained in page1. Return the
                     // byte position for page0, and the timestamp of the first sample in page1, so
                     // that when packets from page1 are read, those packets will have a non-zero
@@ -225,7 +221,7 @@ impl OggReader {
         // first page.
         assert!(self.pages.header().is_first_page);
 
-        info!("starting new physical stream");
+        trace!("starting new physical stream");
 
         // The first page of each logical stream, marked with the first page flag, must contain the
         // identification packet for the encapsulated codec bitstream. The first page for each
@@ -245,7 +241,7 @@ impl OggReader {
             if let Some(pkt) = self.pages.first_packet() {
                 // If a stream mapper has been detected, create a logical stream with it.
                 if let Some(mapper) = mappings::detect(pkt)? {
-                    info!(
+                    trace!(
                         "selected {} mapper for stream with serial={:#x}",
                         mapper.name(),
                         header.serial
@@ -416,8 +412,7 @@ impl FormatReader for OggReader {
                             return seek_error(SeekErrorKind::OutOfRange);
                         }
                     }
-                }
-                else {
+                } else {
                     return seek_error(SeekErrorKind::InvalidTrack);
                 }
 
@@ -428,11 +423,9 @@ impl FormatReader for OggReader {
                 // Get the track serial.
                 let serial = if let Some(serial) = track_id {
                     serial
-                }
-                else if let Some(default_track) = self.default_track() {
+                } else if let Some(default_track) = self.default_track() {
                     default_track.id
-                }
-                else {
+                } else {
                     // No tracks.
                     return seek_error(SeekErrorKind::Unseekable);
                 };
@@ -443,8 +436,7 @@ impl FormatReader for OggReader {
 
                     let ts = if let Some(sample_rate) = params.sample_rate {
                         TimeBase::new(1, sample_rate).calc_timestamp(time)
-                    }
-                    else {
+                    } else {
                         // No sample rate. This should never happen.
                         return seek_error(SeekErrorKind::Unseekable);
                     };
@@ -462,8 +454,7 @@ impl FormatReader for OggReader {
                     }
 
                     ts
-                }
-                else {
+                } else {
                     // No mapper for track. The user provided a bad track ID.
                     return seek_error(SeekErrorKind::InvalidTrack);
                 };

--- a/symphonia-format-riff/src/common.rs
+++ b/symphonia-format-riff/src/common.rs
@@ -16,7 +16,7 @@ use symphonia_core::errors::{decode_error, end_of_stream_error, Error, Result};
 use symphonia_core::formats::prelude::*;
 use symphonia_core::io::{MediaSourceStream, ReadBytes};
 
-use log::{debug, info};
+use log::{debug, trace};
 
 pub enum ByteOrder {
     LittleEndian,
@@ -45,7 +45,7 @@ pub fn fix_channel_mask(mut channel_mask: u32, n_channels: u16) -> u32 {
     let channel_diff = n_channels as i32 - channel_mask.count_ones() as i32;
 
     if channel_diff != 0 {
-        info!("Channel mask not set correctly, channel positions may be incorrect!");
+        trace!("Channel mask not set correctly, channel positions may be incorrect!");
     }
 
     // Check that the number of ones in the channel mask match the number of channels.
@@ -53,8 +53,7 @@ pub fn fix_channel_mask(mut channel_mask: u32, n_channels: u16) -> u32 {
         // Too few ones in mask so add extra ones above the most significant one
         let shift = 32 - (!channel_mask).leading_ones();
         channel_mask |= ((1 << channel_diff) - 1) << shift;
-    }
-    else {
+    } else {
         // Too many ones in mask so remove the most significant extra ones
         while channel_mask.count_ones() != n_channels as u32 {
             let highest_one = 31 - (!channel_mask).leading_ones();
@@ -162,7 +161,7 @@ impl<T: ParseChunkTag> ChunksReader<T> {
                 Some(chunk) => return Ok(Some(chunk)),
                 None => {
                     // As per the RIFF spec, unknown chunks are to be ignored.
-                    info!(
+                    trace!(
                         "ignoring unknown chunk: tag={}, len={}.",
                         String::from_utf8_lossy(&tag),
                         len

--- a/symphonia-format-wav/src/chunks.rs
+++ b/symphonia-format-wav/src/chunks.rs
@@ -20,7 +20,7 @@ use symphonia_core::io::ReadBytes;
 use symphonia_core::meta::Tag;
 use symphonia_metadata::riff;
 
-use log::info;
+use log::trace;
 
 use crate::PacketInfo;
 
@@ -42,7 +42,7 @@ fn fix_channel_mask(mut channel_mask: u32, n_channels: u16) -> u32 {
     let channel_diff = n_channels as i32 - channel_mask.count_ones() as i32;
 
     if channel_diff != 0 {
-        info!("Channel mask not set correctly, channel positions may be incorrect!");
+        trace!("Channel mask not set correctly, channel positions may be incorrect!");
     }
 
     // Check that the number of ones in the channel mask match the number of channels.
@@ -50,8 +50,7 @@ fn fix_channel_mask(mut channel_mask: u32, n_channels: u16) -> u32 {
         // Too few ones in mask so add extra ones above the most significant one
         let shift = 32 - (!channel_mask).leading_ones();
         channel_mask |= ((1 << channel_diff) - 1) << shift;
-    }
-    else {
+    } else {
         // Too many ones in mask so remove the most significant extra ones
         while channel_mask.count_ones() != n_channels as u32 {
             let highest_one = 31 - (!channel_mask).leading_ones();
@@ -149,7 +148,7 @@ impl<T: ParseChunkTag> ChunksReader<T> {
                 Some(chunk) => return Ok(Some(chunk)),
                 None => {
                     // As per the RIFF spec, unknown chunks are to be ignored.
-                    info!(
+                    trace!(
                         "ignoring unknown chunk: tag={}, len={}.",
                         String::from_utf8_lossy(&tag),
                         len
@@ -377,8 +376,7 @@ impl WaveFormatChunk {
             if extra_size != 0 {
                 return decode_error("wav: extra data not expected for fmt_ieee chunk");
             }
-        }
-        else if len > 16 {
+        } else if len > 16 {
             return decode_error("wav: malformed fmt_ieee chunk");
         }
 

--- a/symphonia-metadata/src/id3v2/mod.rs
+++ b/symphonia-metadata/src/id3v2/mod.rs
@@ -13,7 +13,7 @@ use symphonia_core::meta::{MetadataBuilder, MetadataOptions, MetadataReader, Met
 use symphonia_core::probe::{Descriptor, Instantiate, QueryDescriptor};
 use symphonia_core::support_metadata;
 
-use log::{info, trace, warn};
+use log::{trace, warn};
 
 mod frames;
 mod unsync;
@@ -321,7 +321,7 @@ fn read_id3v2_body<B: ReadBytes + FiniteStream>(
             }
             // An unknown frame was encountered.
             FrameResult::UnsupportedFrame(ref id) => {
-                info!("unsupported frame {}", id);
+                trace!("unsupported frame {}", id);
             }
             // The frame contained invalid data.
             FrameResult::InvalidData(ref id) => {

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -26,7 +26,7 @@ use symphonia::core::probe::{Hint, ProbeResult};
 use symphonia::core::units::{Time, TimeBase};
 
 use clap::{Arg, ArgMatches};
-use log::{error, info, warn};
+use log::{error, trace, warn};
 
 mod output;
 
@@ -108,8 +108,7 @@ fn run(args: &ArgMatches) -> Result<i32> {
     // If the path string is '-' then read from standard input.
     let source = if path_str == "-" {
         Box::new(ReadOnlySource::new(std::io::stdin())) as Box<dyn MediaSource>
-    }
-    else {
+    } else {
         // Othwerise, get a Path from the path string.
         let path = Path::new(path_str);
 
@@ -147,17 +146,14 @@ fn run(args: &ArgMatches) -> Result<i32> {
             if args.is_present("verify-only") {
                 // Verify-only mode decodes and verifies the audio, but does not play it.
                 decode_only(probed.format, &DecoderOptions { verify: true, ..Default::default() })
-            }
-            else if args.is_present("decode-only") {
+            } else if args.is_present("decode-only") {
                 // Decode-only mode decodes the audio, but does not play or verify it.
                 decode_only(probed.format, &DecoderOptions { verify: false, ..Default::default() })
-            }
-            else if args.is_present("probe-only") {
+            } else if args.is_present("probe-only") {
                 // Probe-only mode only prints information about the format, tracks, metadata, etc.
                 print_format(path_str, &mut probed);
                 Ok(0)
-            }
-            else {
+            } else {
                 // Playback mode.
                 print_format(path_str, &mut probed);
 
@@ -174,7 +170,7 @@ fn run(args: &ArgMatches) -> Result<i32> {
         }
         Err(err) => {
             // The input was not supported by any format reader.
-            info!("the input is not supported");
+            trace!("the input is not supported");
             Err(err)
         }
     }
@@ -264,8 +260,7 @@ fn play(
                 0
             }
         }
-    }
-    else {
+    } else {
         // If not seeking, the seek timestamp is 0.
         0
     };
@@ -359,8 +354,7 @@ fn play_track(
 
                     // Try to open the audio output.
                     audio_output.replace(output::try_open(spec, duration).unwrap());
-                }
-                else {
+                } else {
                     // TODO: Check the audio spec. and duration hasn't changed.
                 }
 
@@ -439,11 +433,10 @@ fn print_format(path: &str, probed: &mut ProbeResult) {
 
         // Warn that certain tags are preferred.
         if probed.metadata.get().as_ref().is_some() {
-            info!("tags that are part of the container format are preferentially printed.");
-            info!("not printing additional tags that were found while probing.");
+            trace!("tags that are part of the container format are preferentially printed.");
+            trace!("not printing additional tags that were found while probing.");
         }
-    }
-    else if let Some(metadata_rev) = probed.metadata.get().as_ref().and_then(|m| m.current()) {
+    } else if let Some(metadata_rev) = probed.metadata.get().as_ref().and_then(|m| m.current()) {
         print_tags(metadata_rev.tags());
         print_visuals(metadata_rev.visuals());
     }
@@ -472,8 +465,7 @@ fn print_tracks(tracks: &[Track]) {
 
             if let Some(codec) = symphonia::default::get_codecs().get_codec(params.codec) {
                 println!("{} ({})", codec.long_name, codec.short_name);
-            }
-            else {
+            } else {
                 println!("Unknown (#{})", params.codec);
             }
 
@@ -487,8 +479,7 @@ fn print_tracks(tracks: &[Track]) {
                         fmt_time(params.start_ts, tb),
                         params.start_ts
                     );
-                }
-                else {
+                } else {
                     println!("|          Start Time:      {}", params.start_ts);
                 }
             }
@@ -499,8 +490,7 @@ fn print_tracks(tracks: &[Track]) {
                         fmt_time(n_frames, tb),
                         n_frames
                     );
-                }
-                else {
+                } else {
                     println!("|          Frames:          {}", n_frames);
                 }
             }
@@ -552,8 +542,7 @@ fn print_cues(cues: &[Cue]) {
                             "{}",
                             print_tag_item(tidx + 1, &format!("{:?}", std_key), &tag.value, 21)
                         );
-                    }
-                    else {
+                    } else {
                         println!("{}", print_tag_item(tidx + 1, &tag.key, &tag.value, 21));
                     }
                 }
@@ -615,8 +604,7 @@ fn print_visuals(visuals: &[Visual]) {
             if let Some(usage) = visual.usage {
                 println!("|     [{:0>2}] Usage:      {:?}", idx + 1, usage);
                 println!("|          Media Type: {}", visual.media_type);
-            }
-            else {
+            } else {
                 println!("|     [{:0>2}] Media Type: {}", idx + 1, visual.media_type);
             }
             if let Some(dimensions) = visual.dimensions {
@@ -644,8 +632,7 @@ fn print_visuals(visuals: &[Visual]) {
                         "{}",
                         print_tag_item(tidx + 1, &format!("{:?}", std_key), &tag.value, 21)
                     );
-                }
-                else {
+                } else {
                     println!("{}", print_tag_item(tidx + 1, &tag.key, &tag.value, 21));
                 }
             }
@@ -737,8 +724,7 @@ fn print_progress(ts: u64, dur: Option<u64>, tb: Option<TimeBase>) {
             write!(output, " {} -{}:{:0>2}:{:0>4.1}", progress_bar(ts, dur), hours, mins, secs)
                 .unwrap();
         }
-    }
-    else {
+    } else {
         write!(output, "\r\u{25b6}\u{fe0f}  {}", ts).unwrap();
     }
 

--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -253,8 +253,7 @@ mod cpal {
                     sample_rate: cpal::SampleRate(spec.rate),
                     buffer_size: cpal::BufferSize::Default,
                 }
-            }
-            else {
+            } else {
                 // Use the default config for Windows.
                 device
                     .default_output_config()
@@ -299,10 +298,9 @@ mod cpal {
             let sample_buf = SampleBuffer::<T>::new(duration, spec);
 
             let resampler = if spec.rate != config.sample_rate.0 {
-                info!("resampling {} Hz to {} Hz", spec.rate, config.sample_rate.0);
+                trace!("resampling {} Hz to {} Hz", spec.rate, config.sample_rate.0);
                 Some(Resampler::new(spec, config.sample_rate.0 as usize, duration))
-            }
-            else {
+            } else {
                 None
             };
 
@@ -324,8 +322,7 @@ mod cpal {
                     Some(resampled) => resampled,
                     None => return Ok(()),
                 }
-            }
-            else {
+            } else {
                 // Resampling is not required. Interleave the sample for cpal using a sample buffer.
                 self.sample_buf.copy_interleaved_ref(decoded);
 


### PR DESCRIPTION
This will prevent polluting other applications' logs with informations that are better suited to the `debug!` or `trace!` macro.

I went for `trace!` as I think it suits this role better, besides `debug!` is already used in the crate for some other information types.