### PR TITLE
ogg: Decode opus packet durations

### DIFF
--- a/symphonia-format-ogg/src/mappings/opus.rs
+++ b/symphonia-format-ogg/src/mappings/opus.rs
@@ -150,9 +150,59 @@ pub fn detect(buf: &[u8]) -> Result<Option<Box<dyn Mapper>>> {
 pub struct OpusPacketParser {}
 
 impl PacketParser for OpusPacketParser {
-    fn parse_next_packet_dur(&mut self, _packet: &[u8]) -> u64 {
-        // TODO: Implement.
-        0
+    fn parse_next_packet_dur(&mut self, packet: &[u8]) -> u64 {
+        // See https://www.rfc-editor.org/rfc/rfc6716
+        // Read TOC (Table Of Contents) byte which is the first byte in the opus data.
+        let toc_byte = match packet.get(0) {
+            Some(b) => b,
+            None => {
+                warn!("opus packet empty");
+                return 0;
+            }
+        };
+        // The configuration number is the 5 most significant bits. Shift out 3 least significant bits.
+        let configuration_number = toc_byte >> 3; // max 2^5-1 = 31
+
+        // The configuration number maps to packet length according to this lookup table.
+        // See https://www.rfc-editor.org/rfc/rfc6716 top half of page 14.
+        // Numbers are in milliseconds in the rfc. Down below they are in TimeBase units, so 10ms = 10*48.
+        #[rustfmt::skip]
+        const CONFIGURATION_NUMBER_TO_FRAME_DURATION: [u32; 32] = [
+            10*48, 20*48, 40*48, 60*48,
+            10*48, 20*48, 40*48, 60*48,
+            10*48, 20*48, 40*48, 60*48,
+            10*48, 20*48,
+            10*48, 20*48,
+            (2.5*48.0) as u32, 5*48, 10*48, 20*48,
+            (2.5*48.0) as u32, 5*48, 10*48, 20*48,
+            (2.5*48.0) as u32, 5*48, 10*48, 20*48,
+            (2.5*48.0) as u32, 5*48, 10*48, 20*48,
+        ];
+        // Look up the frame length.
+        let frame_duration = CONFIGURATION_NUMBER_TO_FRAME_DURATION[configuration_number as usize] as u64;
+
+        // Look up the number of frames in the packet.
+        // See https://www.rfc-editor.org/rfc/rfc6716 bottom half of page 14.
+        let c = toc_byte & 0b11; // Note: it's actually called "c" in the rfc.
+        let num_frames = match c {
+            0 => 1,
+            1 | 2 => 2,
+            3 => match packet.get(1) {
+                Some(byte) => {
+                    // TOC byte is followed by number of frames. See page 18 section 3.2.5 code 3
+                    let m = byte & 0b11111; // Note: it's actually called "M" in the rfc.
+                    m as u64
+                },
+                None => {
+                    // What to do here? I'd like to return an error but this is an infalliable trait.
+                    warn!("opus code 3 packet with no following byte containing number of frames");
+                    return 0;
+                }
+            },
+            _ => unreachable!("masked 2 bits"),
+        };
+        // Look up the packet length and return it.
+        frame_duration * num_frames
     }
 }
 
@@ -184,9 +234,8 @@ impl Mapper for OpusMapper {
 
     fn map_packet(&mut self, packet: &[u8]) -> Result<MapResult> {
         if !self.need_comment {
-            Ok(MapResult::StreamData { dur: 0 })
-        }
-        else {
+            Ok(MapResult::StreamData { dur: OpusPacketParser {}.parse_next_packet_dur(packet) })
+        } else {
             let mut reader = BufReader::new(packet);
 
             // Read the header signature.
@@ -202,8 +251,7 @@ impl Mapper for OpusMapper {
                 self.need_comment = false;
 
                 Ok(MapResult::SideData { data: SideData::Metadata(builder.metadata()) })
-            }
-            else {
+            } else {
                 warn!("ogg (opus): invalid packet type");
                 Ok(MapResult::Unknown)
             }

--- a/symphonia-format-ogg/src/mappings/opus.rs
+++ b/symphonia-format-ogg/src/mappings/opus.rs
@@ -160,12 +160,14 @@ impl PacketParser for OpusPacketParser {
                 return 0;
             }
         };
-        // The configuration number is the 5 most significant bits. Shift out 3 least significant bits.
+        // The configuration number is the 5 most significant bits. Shift out 3 least significant
+        // bits.
         let configuration_number = toc_byte >> 3; // max 2^5-1 = 31
 
         // The configuration number maps to packet length according to this lookup table.
         // See https://www.rfc-editor.org/rfc/rfc6716 top half of page 14.
-        // Numbers are in milliseconds in the rfc. Down below they are in TimeBase units, so 10ms = 10*48.
+        // Numbers are in milliseconds in the rfc. Down below they are in TimeBase units, so
+        // 10ms = 10*48.
         #[rustfmt::skip]
         const CONFIGURATION_NUMBER_TO_FRAME_DURATION: [u32; 32] = [
             10*48, 20*48, 40*48, 60*48,
@@ -179,7 +181,8 @@ impl PacketParser for OpusPacketParser {
             (2.5*48.0) as u32, 5*48, 10*48, 20*48,
         ];
         // Look up the frame length.
-        let frame_duration = CONFIGURATION_NUMBER_TO_FRAME_DURATION[configuration_number as usize] as u64;
+        let frame_duration =
+            CONFIGURATION_NUMBER_TO_FRAME_DURATION[configuration_number as usize] as u64;
 
         // Look up the number of frames in the packet.
         // See https://www.rfc-editor.org/rfc/rfc6716 bottom half of page 14.
@@ -192,9 +195,10 @@ impl PacketParser for OpusPacketParser {
                     // TOC byte is followed by number of frames. See page 18 section 3.2.5 code 3
                     let m = byte & 0b11111; // Note: it's actually called "M" in the rfc.
                     m as u64
-                },
+                }
                 None => {
-                    // What to do here? I'd like to return an error but this is an infalliable trait.
+                    // What to do here? I'd like to return an error but this is an infalliable
+                    // trait.
                     warn!("opus code 3 packet with no following byte containing number of frames");
                     return 0;
                 }
@@ -235,7 +239,8 @@ impl Mapper for OpusMapper {
     fn map_packet(&mut self, packet: &[u8]) -> Result<MapResult> {
         if !self.need_comment {
             Ok(MapResult::StreamData { dur: OpusPacketParser {}.parse_next_packet_dur(packet) })
-        } else {
+        }
+        else {
             let mut reader = BufReader::new(packet);
 
             // Read the header signature.
@@ -251,7 +256,8 @@ impl Mapper for OpusMapper {
                 self.need_comment = false;
 
                 Ok(MapResult::SideData { data: SideData::Metadata(builder.metadata()) })
-            } else {
+            }
+            else {
                 warn!("ogg (opus): invalid packet type");
                 Ok(MapResult::Unknown)
             }


### PR DESCRIPTION
I implemented this because buffering some ogg web streams seemed to hang trying to buffer up 1s of data. Turns out it was opus and the durations of all opus packets were demuxed as 0. I think I implemented this correctly but don't take my word for it. Maybe it could be of use?