### PR TITLE
Allow non-static sources

### DIFF
--- a/symphonia-bundle-flac/src/demuxer.rs
+++ b/symphonia-bundle-flac/src/demuxer.rs
@@ -150,7 +150,7 @@ impl Probeable for FlacReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for FlacReader<'s> {
+impl<'s> BuildFormatReader<'s> for FlacReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // Read the first 4 bytes of the stream. Ideally this will be the FLAC stream marker.
         let marker = source.read_quad_bytes()?;
@@ -172,7 +172,9 @@ impl<'s> FormatReader<'s> for FlacReader<'s> {
 
         Ok(flac)
     }
+}
 
+impl FormatReader for FlacReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &FLAC_FORMAT_INFO
     }
@@ -337,7 +339,10 @@ impl<'s> FormatReader<'s> for FlacReader<'s> {
         Ok(SeekedTo { track_id: 0, actual_ts: packet.ts, required_ts: ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -43,8 +43,8 @@ const MP3_FORMAT_INFO: FormatInfo = FormatInfo {
 /// MPEG1 and MPEG2 audio elementary stream reader.
 ///
 /// `MpaReader` implements a demuxer for the MPEG1 and MPEG2 audio elementary stream.
-pub struct MpaReader {
-    reader: MediaSourceStream,
+pub struct MpaReader<'s> {
+    reader: MediaSourceStream<'s>,
     tracks: Vec<Track>,
     cues: Vec<Cue>,
     metadata: MetadataLog,
@@ -53,11 +53,12 @@ pub struct MpaReader {
     next_packet_ts: u64,
 }
 
-impl Probeable for MpaReader {
+impl Probeable for MpaReader<'_> {
     fn probe_descriptor() -> &'static [ProbeDescriptor] {
         &[
             // Layer 1
             support_format!(
+                MpaReader<'_>,
                 MP1_FORMAT_INFO,
                 &["mp1"],
                 &["audio/mpeg", "audio/mp1"],
@@ -72,6 +73,7 @@ impl Probeable for MpaReader {
             ),
             // Layer 2
             support_format!(
+                MpaReader<'_>,
                 MP2_FORMAT_INFO,
                 &["mp2"],
                 &["audio/mpeg", "audio/mp2"],
@@ -86,6 +88,7 @@ impl Probeable for MpaReader {
             ),
             // Layer 3
             support_format!(
+                MpaReader<'_>,
                 MP3_FORMAT_INFO,
                 &["mp3"],
                 &["audio/mpeg", "audio/mp3"],
@@ -101,7 +104,7 @@ impl Probeable for MpaReader {
         ]
     }
 
-    fn score(mut src: ScopedStream<&mut MediaSourceStream>) -> Result<Score> {
+    fn score(mut src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score> {
         // Read the sync word for the first (assumed) MPEG frame and try to parse it into a header.
         let sync1 = header::read_frame_header_word_no_sync(&mut src)?;
         let hdr1 = header::parse_frame_header(sync1)?;
@@ -132,8 +135,8 @@ impl Probeable for MpaReader {
     }
 }
 
-impl FormatReader for MpaReader {
-    fn try_new(mut source: MediaSourceStream, options: FormatOptions) -> Result<Self> {
+impl<'s> FormatReader<'s> for MpaReader<'s> {
+    fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // Try to read the first MPEG frame.
         let (header, packet) = read_mpeg_frame_strict(&mut source)?;
 
@@ -467,12 +470,12 @@ impl FormatReader for MpaReader {
         Ok(SeekedTo { track_id: 0, required_ts: required_ts - delay, actual_ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
         self.reader
     }
 }
 
-impl MpaReader {
+impl MpaReader<'_> {
     /// Seeks the media source stream to a byte position roughly where the packet with the required
     /// timestamp should be located.
     fn preseek_coarse(&mut self, required_ts: u64, duration: Option<u64>) -> Result<()> {
@@ -542,7 +545,7 @@ impl MpaReader {
 }
 
 /// Reads a MPEG frame and returns the header and buffer.
-fn read_mpeg_frame(reader: &mut MediaSourceStream) -> Result<(FrameHeader, Vec<u8>)> {
+fn read_mpeg_frame(reader: &mut MediaSourceStream<'_>) -> Result<(FrameHeader, Vec<u8>)> {
     let (header, header_word) = loop {
         // Sync to the next frame header.
         let sync = header::sync_frame(reader)?;
@@ -567,7 +570,7 @@ fn read_mpeg_frame(reader: &mut MediaSourceStream) -> Result<(FrameHeader, Vec<u
 }
 
 /// Reads a MPEG frame and checks if the next frame begins after the packet.
-fn read_mpeg_frame_strict(reader: &mut MediaSourceStream) -> Result<(FrameHeader, Vec<u8>)> {
+fn read_mpeg_frame_strict(reader: &mut MediaSourceStream<'_>) -> Result<(FrameHeader, Vec<u8>)> {
     loop {
         // Read the next MPEG frame.
         let (header, packet) = read_mpeg_frame(reader)?;
@@ -640,7 +643,7 @@ fn read_main_data_begin<B: ReadBytes>(reader: &mut B, header: &FrameHeader) -> R
 }
 
 /// Estimates the total number of MPEG frames in the media source stream.
-fn estimate_num_mpeg_frames(reader: &mut MediaSourceStream) -> Option<u64> {
+fn estimate_num_mpeg_frames(reader: &mut MediaSourceStream<'_>) -> Option<u64> {
     const MAX_FRAMES: u32 = 16;
     const MAX_LEN: usize = 16 * 1024;
 

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -135,7 +135,7 @@ impl Probeable for MpaReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for MpaReader<'s> {
+impl<'s> BuildFormatReader<'s> for MpaReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // Try to read the first MPEG frame.
         let (header, packet) = read_mpeg_frame_strict(&mut source)?;
@@ -211,7 +211,9 @@ impl<'s> FormatReader<'s> for MpaReader<'s> {
             next_packet_ts: 0,
         })
     }
+}
 
+impl FormatReader for MpaReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         match self.tracks[0].codec_params.codec {
             CODEC_TYPE_MP1 => &MP1_FORMAT_INFO,
@@ -470,7 +472,10 @@ impl<'s> FormatReader<'s> for MpaReader<'s> {
         Ok(SeekedTo { track_id: 0, required_ts: required_ts - delay, actual_ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-bundle-mp3/src/lib.rs
+++ b/symphonia-bundle-mp3/src/lib.rs
@@ -49,4 +49,4 @@ pub use demuxer::MpaReader;
 pub type Mp3Decoder = MpaDecoder;
 
 #[deprecated = "use `symphonia_bundle_mp3::MpaReader` instead"]
-pub type Mp3Reader = MpaReader;
+pub type Mp3Reader<'s> = MpaReader<'s>;

--- a/symphonia-check/src/main.rs
+++ b/symphonia-check/src/main.rs
@@ -146,13 +146,16 @@ struct FlushStats {
 }
 
 struct DecoderInstance {
-    format: Box<dyn FormatReader>,
+    format: Box<dyn FormatReader<'static>>,
     decoder: Box<dyn Decoder>,
     track_id: u32,
 }
 
 impl DecoderInstance {
-    fn try_open(mss: MediaSourceStream, fmt_opts: FormatOptions) -> Result<DecoderInstance> {
+    fn try_open(
+        mss: MediaSourceStream<'static>,
+        fmt_opts: FormatOptions,
+    ) -> Result<DecoderInstance> {
         // Use the default options for metadata and format readers, and the decoder.
         let meta_opts: MetadataOptions = Default::default();
         let dec_opts: DecoderOptions = Default::default();

--- a/symphonia-check/src/main.rs
+++ b/symphonia-check/src/main.rs
@@ -146,7 +146,7 @@ struct FlushStats {
 }
 
 struct DecoderInstance {
-    format: Box<dyn FormatReader<'static>>,
+    format: Box<dyn FormatReader>,
     decoder: Box<dyn Decoder>,
     track_id: u32,
 }

--- a/symphonia-codec-aac/src/adts.rs
+++ b/symphonia-codec-aac/src/adts.rs
@@ -212,7 +212,7 @@ impl AdtsHeader {
     }
 }
 
-impl<'s> FormatReader<'s> for AdtsReader<'s> {
+impl<'s> BuildFormatReader<'s> for AdtsReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         let header = AdtsHeader::read(&mut source)?;
 
@@ -247,7 +247,9 @@ impl<'s> FormatReader<'s> for AdtsReader<'s> {
             next_packet_ts: 0,
         })
     }
+}
 
+impl FormatReader for AdtsReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &ADTS_FORMAT_INFO
     }
@@ -370,7 +372,10 @@ impl<'s> FormatReader<'s> for AdtsReader<'s> {
         Ok(SeekedTo { track_id: 0, required_ts, actual_ts: self.next_packet_ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-codec-aac/tests/tests.rs
+++ b/symphonia-codec-aac/tests/tests.rs
@@ -1,7 +1,7 @@
 use symphonia_codec_aac::{AacDecoder, AdtsReader};
 use symphonia_core::codecs::{CodecParameters, Decoder, DecoderOptions, CODEC_TYPE_AAC};
 use symphonia_core::errors;
-use symphonia_core::formats::FormatReader;
+use symphonia_core::formats::{BuildFormatReader, FormatReader};
 use symphonia_core::io::MediaSourceStream;
 
 fn test_decode(data: Vec<u8>) -> symphonia_core::errors::Result<()> {

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -229,11 +229,11 @@ impl Track {
 /// `FormatReader` provides an Iterator-like interface over packets for easy consumption and
 /// filtering. Seeking will invalidate the state of any `Decoder` processing packets from the
 /// `FormatReader` and should be reset after a successful seek operation.
-pub trait FormatReader: Send + Sync {
+pub trait FormatReader<'s>: Send + Sync {
     /// Attempt to instantiate a `FormatReader` using the provided `FormatOptions` and
     /// `MediaSourceStream`. The reader will probe the container to verify format support, determine
     /// the number of tracks, and read any initial metadata.
-    fn try_new(source: MediaSourceStream, options: FormatOptions) -> Result<Self>
+    fn try_new(source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self>
     where
         Self: Sized;
 
@@ -280,7 +280,7 @@ pub trait FormatReader: Send + Sync {
     fn next_packet(&mut self) -> Result<Option<Packet>>;
 
     /// Destroys the `FormatReader` and returns the underlying media source stream
-    fn into_inner(self: Box<Self>) -> MediaSourceStream;
+    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s>;
 }
 
 /// A `Packet` contains a discrete amount of encoded data for a single codec bitstream. The exact

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -93,10 +93,8 @@ pub enum ProbeCandidate {
         /// A basic description about the container format.
         info: FormatInfo,
         /// A factory function to create an instance of the format reader.
-        factory: for<'s> fn(
-            MediaSourceStream<'s>,
-            FormatOptions,
-        ) -> Result<Box<dyn FormatReader<'s> + 's>>,
+        factory:
+            for<'s> fn(MediaSourceStream<'s>, FormatOptions) -> Result<Box<dyn FormatReader + 's>>,
     },
     Metadata {
         /// A basic description about the metadata format.
@@ -355,7 +353,7 @@ impl Probe {
         mut mss: MediaSourceStream<'s>,
         mut fmt_opts: FormatOptions,
         meta_opts: MetadataOptions,
-    ) -> Result<Box<dyn FormatReader<'s> + 's>> {
+    ) -> Result<Box<dyn FormatReader + 's>> {
         // Loop over all elements in the stream until a container format is found.
         loop {
             match self.next(&mut mss, hint)? {

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -93,7 +93,10 @@ pub enum ProbeCandidate {
         /// A basic description about the container format.
         info: FormatInfo,
         /// A factory function to create an instance of the format reader.
-        factory: fn(MediaSourceStream, FormatOptions) -> Result<Box<dyn FormatReader>>,
+        factory: for<'s> fn(
+            MediaSourceStream<'s>,
+            FormatOptions,
+        ) -> Result<Box<dyn FormatReader<'s> + 's>>,
     },
     Metadata {
         /// A basic description about the metadata format.
@@ -115,7 +118,7 @@ pub struct ProbeDescriptor {
     pub markers: &'static [&'static [u8]],
     /// A function to assign a likelyhood score that the media source, readable with scoped access
     /// via. the provided stream, is the start of a metadate or container format
-    pub score: fn(ScopedStream<&mut MediaSourceStream>) -> Result<Score>,
+    pub score: fn(ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score>,
     /// If the probe descriptor matches the byte stream, then the probe candidate describes the
     /// metadata or container format reader, and provides a factory function to instantiate it.
     pub candidate: ProbeCandidate,
@@ -144,7 +147,7 @@ pub trait Probeable {
     /// If an error is returned, errors other than [`Error::IoError`] (excluding the unexpected EOF
     /// kind) are treated as if [`Score::Unsupported`] was returned. All other IO errors abort
     /// the probe operation.
-    fn score(src: ScopedStream<&mut MediaSourceStream>) -> Result<Score>;
+    fn score(src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score>;
 }
 
 /// A `Hint` provides additional information and context when probing a media source stream.
@@ -346,13 +349,13 @@ impl Probe {
     /// Searches the provided `MediaSourceStream` for a container format. Any metadata that is read
     /// during the search will be queued and attached to the `FormatReader` instance once a
     /// container format is found.
-    pub fn format(
+    pub fn format<'s>(
         &self,
         hint: &Hint,
-        mut mss: MediaSourceStream,
+        mut mss: MediaSourceStream<'s>,
         mut fmt_opts: FormatOptions,
         meta_opts: MetadataOptions,
-    ) -> Result<Box<dyn FormatReader>> {
+    ) -> Result<Box<dyn FormatReader<'s> + 's>> {
         // Loop over all elements in the stream until a container format is found.
         loop {
             match self.next(&mut mss, hint)? {
@@ -470,7 +473,7 @@ fn warn_junk_bytes(pos: u64, init_pos: u64) {
 /// Convenience macro for declaring a probe `ProbeDescriptor` for a `FormatReader`.
 #[macro_export]
 macro_rules! support_format {
-    ($info:expr, $exts:expr, $mimes:expr, $markers:expr) => {
+    ($typ:ty, $info:expr, $exts:expr, $mimes:expr, $markers:expr) => {
         symphonia_core::probe::ProbeDescriptor {
             extensions: $exts,
             mime_types: $mimes,
@@ -478,7 +481,7 @@ macro_rules! support_format {
             score: Self::score,
             candidate: symphonia_core::probe::ProbeCandidate::Format {
                 info: $info,
-                factory: |src, opts| Ok(Box::new(Self::try_new(src, opts)?)),
+                factory: |src, opts| Ok(Box::new(<$typ>::try_new(src, opts)?)),
             },
         }
     };

--- a/symphonia-format-caf/src/chunks.rs
+++ b/symphonia-format-caf/src/chunks.rs
@@ -79,7 +79,7 @@ impl Chunk {
     /// The first chunk read will be the AudioDescription chunk. Once it's been read, the caller
     /// should pass it in to subsequent read calls.
     pub fn read(
-        reader: &mut MediaSourceStream,
+        reader: &mut MediaSourceStream<'_>,
         audio_description: &Option<AudioDescription>,
     ) -> Result<Option<Self>> {
         let chunk_type = reader.read_quad_bytes()?;
@@ -140,7 +140,7 @@ pub struct AudioDescription {
 }
 
 impl AudioDescription {
-    pub fn read(reader: &mut MediaSourceStream, chunk_size: i64) -> Result<Self> {
+    pub fn read(reader: &mut MediaSourceStream<'_>, chunk_size: i64) -> Result<Self> {
         if chunk_size != 32 {
             return invalid_chunk_size_error("Audio Description", chunk_size);
         }
@@ -236,7 +236,7 @@ pub struct AudioData {
 }
 
 impl AudioData {
-    pub fn read(reader: &mut MediaSourceStream, chunk_size: i64) -> Result<Self> {
+    pub fn read(reader: &mut MediaSourceStream<'_>, chunk_size: i64) -> Result<Self> {
         let edit_count_offset = size_of::<u32>() as i64;
 
         if chunk_size != -1 && chunk_size < edit_count_offset {
@@ -275,7 +275,7 @@ pub enum AudioDescriptionFormatId {
 }
 
 impl AudioDescriptionFormatId {
-    pub fn read(reader: &mut MediaSourceStream) -> Result<Self> {
+    pub fn read(reader: &mut MediaSourceStream<'_>) -> Result<Self> {
         use AudioDescriptionFormatId::*;
 
         let format_id = reader.read_quad_bytes()?;
@@ -328,7 +328,7 @@ pub struct ChannelLayout {
 }
 
 impl ChannelLayout {
-    pub fn read(reader: &mut MediaSourceStream, chunk_size: i64) -> Result<Self> {
+    pub fn read(reader: &mut MediaSourceStream<'_>, chunk_size: i64) -> Result<Self> {
         if chunk_size < 12 {
             return invalid_chunk_size_error("Channel Layout", chunk_size);
         }
@@ -436,7 +436,7 @@ pub struct ChannelDescription {
 }
 
 impl ChannelDescription {
-    pub fn read(reader: &mut MediaSourceStream) -> Result<Self> {
+    pub fn read(reader: &mut MediaSourceStream<'_>) -> Result<Self> {
         Ok(Self {
             channel_label: reader.read_be_u32()?,
             channel_flags: reader.read_be_u32()?,
@@ -454,7 +454,7 @@ pub struct PacketTable {
 
 impl PacketTable {
     pub fn read(
-        reader: &mut MediaSourceStream,
+        reader: &mut MediaSourceStream<'_>,
         desc: &Option<AudioDescription>,
         chunk_size: i64,
     ) -> Result<Self> {
@@ -583,7 +583,7 @@ fn invalid_chunk_size_error<T>(chunk_type: &str, chunk_size: i64) -> Result<T> {
     decode_error("caf: invalid chunk size")
 }
 
-fn read_variable_length_integer(reader: &mut MediaSourceStream) -> Result<u64> {
+fn read_variable_length_integer(reader: &mut MediaSourceStream<'_>) -> Result<u64> {
     let mut result = 0;
 
     for _ in 0..9 {

--- a/symphonia-format-caf/src/demuxer.rs
+++ b/symphonia-format-caf/src/demuxer.rs
@@ -54,7 +54,7 @@ impl Probeable for CafReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for CafReader<'s> {
+impl<'s> BuildFormatReader<'s> for CafReader<'s> {
     fn try_new(source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         let mut reader = Self {
             reader: source,
@@ -73,7 +73,9 @@ impl<'s> FormatReader<'s> for CafReader<'s> {
 
         Ok(reader)
     }
+}
 
+impl FormatReader for CafReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &CAF_FORMAT_INFO
     }
@@ -241,7 +243,10 @@ impl<'s> FormatReader<'s> for CafReader<'s> {
         }
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -336,7 +336,7 @@ impl Probeable for IsoMp4Reader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for IsoMp4Reader<'s> {
+impl<'s> BuildFormatReader<'s> for IsoMp4Reader<'s> {
     fn try_new(mut mss: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // To get to beginning of the atom.
         mss.seek_buffered_rel(-4);
@@ -505,7 +505,9 @@ impl<'s> FormatReader<'s> for IsoMp4Reader<'s> {
             moov,
         })
     }
+}
 
+impl FormatReader for IsoMp4Reader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &ISOMP4_FORMAT_INFO
     }
@@ -618,7 +620,10 @@ impl<'s> FormatReader<'s> for IsoMp4Reader<'s> {
         }
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.iter.into_inner()
     }
 }

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -314,7 +314,7 @@ impl MkvReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for MkvReader<'s> {
+impl<'s> BuildFormatReader<'s> for MkvReader<'s> {
     fn try_new(mut reader: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self>
     where
         Self: Sized,
@@ -527,7 +527,9 @@ impl<'s> FormatReader<'s> for MkvReader<'s> {
             clusters,
         })
     }
+}
 
+impl FormatReader for MkvReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &MKV_FORMAT_INFO
     }
@@ -588,7 +590,10 @@ impl<'s> FormatReader<'s> for MkvReader<'s> {
         }
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.iter.into_inner()
     }
 }

--- a/symphonia-format-ogg/src/demuxer.rs
+++ b/symphonia-format-ogg/src/demuxer.rs
@@ -391,7 +391,7 @@ impl Probeable for OggReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for OggReader<'s> {
+impl<'s> BuildFormatReader<'s> for OggReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // A seekback buffer equal to the maximum OGG page size is required for this reader.
         source.ensure_seekback_buffer(OGG_PAGE_MAX_SIZE);
@@ -418,7 +418,9 @@ impl<'s> FormatReader<'s> for OggReader<'s> {
 
         Ok(ogg)
     }
+}
 
+impl FormatReader for OggReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &OGG_FORMAT_INFO
     }
@@ -521,7 +523,10 @@ impl<'s> FormatReader<'s> for OggReader<'s> {
         self.do_seek(serial, required_ts)
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-format-ogg/src/demuxer.rs
+++ b/symphonia-format-ogg/src/demuxer.rs
@@ -30,8 +30,8 @@ const OGG_FORMAT_INFO: FormatInfo =
 /// OGG demultiplexer.
 ///
 /// `OggReader` implements a demuxer for Xiph's OGG container format.
-pub struct OggReader {
-    reader: MediaSourceStream,
+pub struct OggReader<'s> {
+    reader: MediaSourceStream<'s>,
     tracks: Vec<Track>,
     cues: Vec<Cue>,
     metadata: MetadataLog,
@@ -46,7 +46,7 @@ pub struct OggReader {
     phys_byte_range_end: Option<u64>,
 }
 
-impl OggReader {
+impl OggReader<'_> {
     fn read_page(&mut self) -> Result<()> {
         // Try reading pages until a page is successfully read, or an IO error.
         loop {
@@ -375,9 +375,10 @@ impl OggReader {
     }
 }
 
-impl Probeable for OggReader {
+impl Probeable for OggReader<'_> {
     fn probe_descriptor() -> &'static [ProbeDescriptor] {
         &[support_format!(
+            OggReader<'_>,
             OGG_FORMAT_INFO,
             &["ogg", "ogv", "oga", "ogx", "ogm", "spx", "opus"],
             &["video/ogg", "audio/ogg", "application/ogg"],
@@ -385,13 +386,13 @@ impl Probeable for OggReader {
         )]
     }
 
-    fn score(_src: ScopedStream<&mut MediaSourceStream>) -> Result<Score> {
+    fn score(_src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score> {
         Ok(Score::Supported(255))
     }
 }
 
-impl FormatReader for OggReader {
-    fn try_new(mut source: MediaSourceStream, options: FormatOptions) -> Result<Self> {
+impl<'s> FormatReader<'s> for OggReader<'s> {
+    fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // A seekback buffer equal to the maximum OGG page size is required for this reader.
         source.ensure_seekback_buffer(OGG_PAGE_MAX_SIZE);
 
@@ -520,7 +521,7 @@ impl FormatReader for OggReader {
         self.do_seek(serial, required_ts)
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
         self.reader
     }
 }

--- a/symphonia-format-ogg/src/physical.rs
+++ b/symphonia-format-ogg/src/physical.rs
@@ -16,7 +16,7 @@ use super::page::*;
 use log::debug;
 
 pub fn probe_stream_start(
-    reader: &mut MediaSourceStream,
+    reader: &mut MediaSourceStream<'_>,
     pages: &mut PageReader,
     streams: &mut BTreeMap<u32, LogicalStream>,
 ) {
@@ -66,7 +66,7 @@ pub fn probe_stream_start(
 }
 
 pub fn probe_stream_end(
-    reader: &mut MediaSourceStream,
+    reader: &mut MediaSourceStream<'_>,
     pages: &mut PageReader,
     streams: &mut BTreeMap<u32, LogicalStream>,
     byte_range_start: u64,
@@ -142,7 +142,7 @@ pub fn probe_stream_end(
 }
 
 fn scan_stream_end(
-    reader: &mut MediaSourceStream,
+    reader: &mut MediaSourceStream<'_>,
     pages: &mut PageReader,
     streams: &mut BTreeMap<u32, LogicalStream>,
     byte_range_end: u64,

--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -200,16 +200,16 @@ impl fmt::Display for CommonChunk {
 }
 
 pub trait CommonChunkParser {
-    fn parse_aiff(self, source: &mut MediaSourceStream) -> Result<CommonChunk>;
-    fn parse_aifc(self, source: &mut MediaSourceStream) -> Result<CommonChunk>;
+    fn parse_aiff(self, source: &mut MediaSourceStream<'_>) -> Result<CommonChunk>;
+    fn parse_aifc(self, source: &mut MediaSourceStream<'_>) -> Result<CommonChunk>;
 }
 
 impl CommonChunkParser for ChunkParser<CommonChunk> {
-    fn parse_aiff(self, source: &mut MediaSourceStream) -> Result<CommonChunk> {
+    fn parse_aiff(self, source: &mut MediaSourceStream<'_>) -> Result<CommonChunk> {
         self.parse(source)
     }
 
-    fn parse_aifc(self, source: &mut MediaSourceStream) -> Result<CommonChunk> {
+    fn parse_aifc(self, source: &mut MediaSourceStream<'_>) -> Result<CommonChunk> {
         let n_channels = source.read_be_i16()?;
         let n_sample_frames = source.read_be_u32()?;
         let sample_size = source.read_be_i16()?;

--- a/symphonia-format-riff/src/aiff/mod.rs
+++ b/symphonia-format-riff/src/aiff/mod.rs
@@ -69,7 +69,7 @@ impl Probeable for AiffReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for AiffReader<'s> {
+impl<'s> BuildFormatReader<'s> for AiffReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // The FORM marker should be present.
         let marker = source.read_quad_bytes()?;
@@ -142,7 +142,9 @@ impl<'s> FormatReader<'s> for AiffReader<'s> {
             }
         }
     }
+}
 
+impl FormatReader for AiffReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &AIFF_FORMAT_INFO
     }
@@ -235,7 +237,10 @@ impl<'s> FormatReader<'s> for AiffReader<'s> {
         Ok(SeekedTo { track_id: 0, actual_ts, required_ts: ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-format-riff/src/aiff/mod.rs
+++ b/symphonia-format-riff/src/aiff/mod.rs
@@ -40,8 +40,8 @@ const AIFF_FORMAT_INFO: FormatInfo = FormatInfo {
 /// Audio Interchange File Format (AIFF) format reader.
 ///
 /// `AiffReader` implements a demuxer for the AIFF container format.
-pub struct AiffReader {
-    reader: MediaSourceStream,
+pub struct AiffReader<'s> {
+    reader: MediaSourceStream<'s>,
     tracks: Vec<Track>,
     cues: Vec<Cue>,
     metadata: MetadataLog,
@@ -50,11 +50,12 @@ pub struct AiffReader {
     data_end_pos: u64,
 }
 
-impl Probeable for AiffReader {
+impl Probeable for AiffReader<'_> {
     fn probe_descriptor() -> &'static [ProbeDescriptor] {
         &[
             // AIFF RIFF form
             support_format!(
+                AiffReader<'_>,
                 AIFF_FORMAT_INFO,
                 &["aiff", "aif", "aifc"],
                 &["audio/aiff", "audio/x-aiff", " sound/aiff", "audio/x-pn-aiff"],
@@ -63,13 +64,13 @@ impl Probeable for AiffReader {
         ]
     }
 
-    fn score(_src: ScopedStream<&mut MediaSourceStream>) -> Result<Score> {
+    fn score(_src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score> {
         Ok(Score::Supported(255))
     }
 }
 
-impl FormatReader for AiffReader {
-    fn try_new(mut source: MediaSourceStream, options: FormatOptions) -> Result<Self> {
+impl<'s> FormatReader<'s> for AiffReader<'s> {
+    fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // The FORM marker should be present.
         let marker = source.read_quad_bytes()?;
         if marker != AIFF_STREAM_MARKER {
@@ -234,7 +235,7 @@ impl FormatReader for AiffReader {
         Ok(SeekedTo { track_id: 0, actual_ts, required_ts: ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
         self.reader
     }
 }

--- a/symphonia-format-riff/src/common.rs
+++ b/symphonia-format-riff/src/common.rs
@@ -262,7 +262,7 @@ impl PacketInfo {
 }
 
 pub fn next_packet(
-    reader: &mut MediaSourceStream,
+    reader: &mut MediaSourceStream<'_>,
     packet_info: &PacketInfo,
     tracks: &[Track],
     data_start_pos: u64,

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -617,7 +617,7 @@ pub fn append_fact_params(codec_params: &mut CodecParameters, fact: &FactChunk) 
     codec_params.with_n_frames(u64::from(fact.n_frames));
 }
 
-pub fn read_info_chunk(source: &mut MediaSourceStream, len: u32) -> Result<MetadataRevision> {
+pub fn read_info_chunk(source: &mut MediaSourceStream<'_>, len: u32) -> Result<MetadataRevision> {
     let mut info_list = ChunksReader::<RiffInfoListChunks>::new(len, ByteOrder::LittleEndian);
 
     let mut metadata_builder = MetadataBuilder::new();

--- a/symphonia-format-riff/src/wave/mod.rs
+++ b/symphonia-format-riff/src/wave/mod.rs
@@ -77,7 +77,7 @@ impl Probeable for WavReader<'_> {
     }
 }
 
-impl<'s> FormatReader<'s> for WavReader<'s> {
+impl<'s> BuildFormatReader<'s> for WavReader<'s> {
     fn try_new(mut source: MediaSourceStream<'s>, options: FormatOptions) -> Result<Self> {
         // The RIFF marker should be present.
         let marker = source.read_quad_bytes()?;
@@ -169,7 +169,9 @@ impl<'s> FormatReader<'s> for WavReader<'s> {
             }
         }
     }
+}
 
+impl FormatReader for WavReader<'_> {
     fn format_info(&self) -> &FormatInfo {
         &WAVE_FORMAT_INFO
     }
@@ -262,7 +264,10 @@ impl<'s> FormatReader<'s> for WavReader<'s> {
         Ok(SeekedTo { track_id: 0, actual_ts, required_ts: ts })
     }
 
-    fn into_inner(self: Box<Self>) -> MediaSourceStream<'s> {
+    fn into_inner<'s>(self: Box<Self>) -> MediaSourceStream<'s>
+    where
+        Self: 's,
+    {
         self.reader
     }
 }

--- a/symphonia-metadata/src/id3v2/mod.rs
+++ b/symphonia-metadata/src/id3v2/mod.rs
@@ -410,7 +410,7 @@ impl Probeable for Id3v2Reader {
         &[support_metadata!(ID3V2_METADATA_INFO, &[], &[], &[b"ID3"])]
     }
 
-    fn score(_src: ScopedStream<&mut MediaSourceStream>) -> Result<Score> {
+    fn score(_src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score> {
         Ok(Score::Supported(255))
     }
 }
@@ -424,7 +424,7 @@ impl MetadataReader for Id3v2Reader {
         &ID3V2_METADATA_INFO
     }
 
-    fn read_all(&mut self, reader: &mut MediaSourceStream) -> Result<MetadataRevision> {
+    fn read_all(&mut self, reader: &mut MediaSourceStream<'_>) -> Result<MetadataRevision> {
         let mut builder = MetadataBuilder::new();
         read_id3v2(reader, &mut builder)?;
         Ok(builder.metadata())

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -227,7 +227,7 @@ fn run(args: &ArgMatches) -> Result<i32> {
     }
 }
 
-fn decode_only(mut reader: Box<dyn FormatReader>, decode_opts: &DecoderOptions) -> Result<i32> {
+fn decode_only(mut reader: Box<dyn FormatReader<'_>>, decode_opts: &DecoderOptions) -> Result<i32> {
     // Get the default track.
     // TODO: Allow track selection.
     let track = reader.default_track().unwrap();
@@ -269,7 +269,7 @@ struct PlayTrackOptions {
 }
 
 fn play(
-    mut reader: Box<dyn FormatReader>,
+    mut reader: Box<dyn FormatReader<'_>>,
     track_num: Option<usize>,
     seek: Option<SeekPosition>,
     decode_opts: &DecoderOptions,
@@ -351,7 +351,7 @@ fn play(
 }
 
 fn play_track(
-    reader: &mut Box<dyn FormatReader>,
+    reader: &mut Box<dyn FormatReader<'_>>,
     audio_output: &mut Option<Box<dyn output::AudioOutput>>,
     play_opts: PlayTrackOptions,
     decode_opts: &DecoderOptions,
@@ -474,7 +474,7 @@ fn dump_visual(visual: &Visual, file_name: &OsStr, index: usize) {
     }
 }
 
-fn dump_visuals(format: &mut Box<dyn FormatReader>, file_name: &OsStr) {
+fn dump_visuals(format: &mut Box<dyn FormatReader<'_>>, file_name: &OsStr) {
     if let Some(metadata) = format.metadata().current() {
         for (i, visual) in metadata.visuals().iter().enumerate() {
             dump_visual(visual, file_name, i);
@@ -482,7 +482,7 @@ fn dump_visuals(format: &mut Box<dyn FormatReader>, file_name: &OsStr) {
     }
 }
 
-fn print_format(path: &Path, format: &mut Box<dyn FormatReader>) {
+fn print_format(path: &Path, format: &mut Box<dyn FormatReader<'_>>) {
     println!("+ {}", path.display());
 
     let format_info = format.format_info();

--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -227,7 +227,7 @@ fn run(args: &ArgMatches) -> Result<i32> {
     }
 }
 
-fn decode_only(mut reader: Box<dyn FormatReader<'_>>, decode_opts: &DecoderOptions) -> Result<i32> {
+fn decode_only(mut reader: Box<dyn FormatReader>, decode_opts: &DecoderOptions) -> Result<i32> {
     // Get the default track.
     // TODO: Allow track selection.
     let track = reader.default_track().unwrap();
@@ -269,7 +269,7 @@ struct PlayTrackOptions {
 }
 
 fn play(
-    mut reader: Box<dyn FormatReader<'_>>,
+    mut reader: Box<dyn FormatReader>,
     track_num: Option<usize>,
     seek: Option<SeekPosition>,
     decode_opts: &DecoderOptions,
@@ -351,7 +351,7 @@ fn play(
 }
 
 fn play_track(
-    reader: &mut Box<dyn FormatReader<'_>>,
+    reader: &mut Box<dyn FormatReader>,
     audio_output: &mut Option<Box<dyn output::AudioOutput>>,
     play_opts: PlayTrackOptions,
     decode_opts: &DecoderOptions,
@@ -474,7 +474,7 @@ fn dump_visual(visual: &Visual, file_name: &OsStr, index: usize) {
     }
 }
 
-fn dump_visuals(format: &mut Box<dyn FormatReader<'_>>, file_name: &OsStr) {
+fn dump_visuals(format: &mut Box<dyn FormatReader>, file_name: &OsStr) {
     if let Some(metadata) = format.metadata().current() {
         for (i, visual) in metadata.visuals().iter().enumerate() {
             dump_visual(visual, file_name, i);
@@ -482,7 +482,7 @@ fn dump_visuals(format: &mut Box<dyn FormatReader<'_>>, file_name: &OsStr) {
     }
 }
 
-fn print_format(path: &Path, format: &mut Box<dyn FormatReader<'_>>) {
+fn print_format(path: &Path, format: &mut Box<dyn FormatReader>) {
     println!("+ {}", path.display());
 
     let format_info = format.format_info();

--- a/symphonia/src/lib.rs
+++ b/symphonia/src/lib.rs
@@ -187,7 +187,7 @@ pub mod default {
 
         #[deprecated = "use `default::formats::MpaReader` instead"]
         #[cfg(any(feature = "mp1", feature = "mp2", feature = "mp3"))]
-        pub type Mp3Reader = MpaReader;
+        pub type Mp3Reader<'s> = MpaReader<'s>;
     }
 
     use lazy_static::lazy_static;
@@ -269,31 +269,31 @@ pub mod default {
 
         // Formats
         #[cfg(feature = "aac")]
-        probe.register_all::<formats::AdtsReader>();
+        probe.register_all::<formats::AdtsReader<'_>>();
 
         #[cfg(feature = "caf")]
-        probe.register_all::<formats::CafReader>();
+        probe.register_all::<formats::CafReader<'_>>();
 
         #[cfg(feature = "flac")]
-        probe.register_all::<formats::FlacReader>();
+        probe.register_all::<formats::FlacReader<'_>>();
 
         #[cfg(feature = "isomp4")]
-        probe.register_all::<formats::IsoMp4Reader>();
+        probe.register_all::<formats::IsoMp4Reader<'_>>();
 
         #[cfg(any(feature = "mp1", feature = "mp2", feature = "mp3"))]
-        probe.register_all::<formats::MpaReader>();
+        probe.register_all::<formats::MpaReader<'_>>();
 
         #[cfg(feature = "aiff")]
-        probe.register_all::<formats::AiffReader>();
+        probe.register_all::<formats::AiffReader<'_>>();
 
         #[cfg(feature = "wav")]
-        probe.register_all::<formats::WavReader>();
+        probe.register_all::<formats::WavReader<'_>>();
 
         #[cfg(feature = "ogg")]
-        probe.register_all::<formats::OggReader>();
+        probe.register_all::<formats::OggReader<'_>>();
 
         #[cfg(feature = "mkv")]
-        probe.register_all::<formats::MkvReader>();
+        probe.register_all::<formats::MkvReader<'_>>();
 
         // Metadata
         probe.register_all::<Id3v2Reader>();


### PR DESCRIPTION
This allows reading data from borrowed buffers and such.

This is a breaking change, because it adds many lifetimes in codebase.

Closes #117