### PR TITLE
Upgrade bitflags to 2.4.1

### DIFF
--- a/symphonia-core/Cargo.toml
+++ b/symphonia-core/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.53"
 
 [dependencies]
 arrayvec = "0.7.1"
-bitflags = "1.2.1"
+bitflags = "2.4.1"
 bytemuck = "1.7"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -32,7 +32,7 @@ bitflags! {
     /// The first 18 defined channels are guaranteed to be identical to those specified by
     /// Microsoft's WAVEFORMATEXTENSIBLE structure. Channels after 18 are defined by Symphonia and
     /// no order is guaranteed.
-    #[derive(Default)]
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Channels: u32 {
         /// Front-left (left) or the Mono channel.
         const FRONT_LEFT         = 0x0000_0001;
@@ -89,41 +89,16 @@ bitflags! {
     }
 }
 
-/// An iterator over individual channels within a `Channels` bitmask.
-pub struct ChannelsIter {
-    channels: Channels,
-}
-
-impl Iterator for ChannelsIter {
-    type Item = Channels;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if !self.channels.is_empty() {
-            let channel = Channels::from_bits_truncate(1 << self.channels.bits.trailing_zeros());
-            self.channels ^= channel;
-            Some(channel)
-        }
-        else {
-            None
-        }
-    }
-}
-
 impl Channels {
     /// Gets the number of channels.
     pub fn count(self) -> usize {
-        self.bits.count_ones() as usize
-    }
-
-    /// Gets an iterator over individual channels.
-    pub fn iter(&self) -> ChannelsIter {
-        ChannelsIter { channels: *self }
+        self.bits().count_ones() as usize
     }
 }
 
 impl fmt::Display for Channels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#032b}", self.bits)
+        write!(f, "{:#032b}", self.bits())
     }
 }
 


### PR DESCRIPTION
This is a breaking change, so should be tagged with 0.6.

Replaces the outdated bitflags 1.2.1 with 2.4.1, which reduces downstream duplicate dependencies and allows removing the ChannelsIter as this is automatically added by the bitflags macro.