### PR TITLE
mkv: get metadata from info element

### DIFF
--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -352,7 +352,9 @@ impl FormatReader for MkvReader {
                     segment_tracks = Some(it.read_element_data::<TracksElement>()?);
                 }
                 ElementType::Info => {
-                    info = Some(it.read_element_data::<InfoElement>()?);
+                    let raw_info = it.read_element_data::<InfoElement>()?;
+                    raw_info.copy_metadata_into(&mut metadata);
+                    info = Some(raw_info);
                 }
                 ElementType::Cues => {
                     let cues = it.read_element_data::<CuesElement>()?;

--- a/symphonia-format-mkv/src/segment.rs
+++ b/symphonia-format-mkv/src/segment.rs
@@ -7,7 +7,7 @@
 
 use symphonia_core::errors::{Error, Result};
 use symphonia_core::io::{BufReader, ReadBytes};
-use symphonia_core::meta::{MetadataBuilder, MetadataRevision, Tag, Value};
+use symphonia_core::meta::{MetadataBuilder, MetadataLog, MetadataRevision, Tag, Value};
 
 use crate::ebml::{read_unsigned_vint, Element, ElementData, ElementHeader};
 use crate::element_ids::ElementType;
@@ -269,13 +269,14 @@ impl Element for EbmlHeaderElement {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct InfoElement {
     pub(crate) timestamp_scale: u64,
     pub(crate) duration: Option<f64>,
     title: Option<Box<str>>,
+    #[allow(dead_code)]
     muxing_app: Box<str>,
+    #[allow(dead_code)]
     writing_app: Box<str>,
 }
 
@@ -320,6 +321,19 @@ impl Element for InfoElement {
             muxing_app: muxing_app.unwrap_or_default().into_boxed_str(),
             writing_app: writing_app.unwrap_or_default().into_boxed_str(),
         })
+    }
+}
+
+impl InfoElement {
+    pub fn copy_metadata_into(&self, metadata_log: &mut MetadataLog) {
+        match self.title.clone() {
+            Some(title) => {
+                let mut metadata = MetadataBuilder::new();
+                metadata.add_tag(Tag::new(None, "title", Value::String(title.to_string())));
+                metadata_log.push(metadata.metadata());
+            }
+            None => return,
+        }
     }
 }
 


### PR DESCRIPTION
As discussed here, https://github.com/pdeljanov/Symphonia/issues/273
I just placed the segment title as a tag. 
When dumping the metadata for an mka file that has both a "tag title" and a "segment title" it looks like this

```
Metadata {
    revisions: [
        MetadataRevision {
            tags: [
                Tag {
                    std_key: None,
                    key: "TITLE",
                    value: String(
                        "real_title",
                    ),
                },
            ],
            visuals: [],
            vendor_data: [],
        },
        MetadataRevision {
            tags: [
                Tag {
                    std_key: None,
                    key: "TITLE",
                    value: String(
                        "tag_title",
                    ),
                },
```

If you think there is a neater way let me know!