### PR TITLE
core: change 'found the format marker' log message from info to debug

### DIFF
--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -276,7 +276,7 @@ impl Probe {
 
                             // TODO: Implement scoring.
 
-                            info!(
+                            debug!(
                                 "found the format marker {:x?} @ {}+{} bytes.",
                                 &context[0..len],
                                 init_pos,


### PR DESCRIPTION
Fixes #272

As in #272, I've also experienced the `info` log flooding for a message that shouldn't really be info. I know we can look at configuring log levels, but the content of the message seems very much debug-like, not informational.

```
...
2024-05-10T00:15:25.274616Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
2024-05-10T00:15:25.276794Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
2024-05-10T00:15:25.286236Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
2024-05-10T00:15:25.300764Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
2024-05-10T00:15:25.302995Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
2024-05-10T00:15:25.312544Z  INFO symphonia_core::probe: found the format marker [52, 49, 46, 46] @ 0+2 bytes.
...
```

Relates to #228.