### PR TITLE
flac: Allow different sample rate between frames

### DIFF
--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -97,6 +97,11 @@ impl FlacDecoder {
 
         let header = read_frame_header(&mut reader, sync)?;
 
+        // Update the sample rate for this frame.
+        if let Some(sample_rate) = header.sample_rate {
+            self.buf.spec_mut().rate = sample_rate;
+        }
+
         // Use the bits per sample and sample rate as stated in the frame header, falling back to
         // the stream information if provided. If neither are available, return an error.
         let bits_per_sample = if let Some(bps) = header.bits_per_sample {

--- a/symphonia-bundle-flac/src/parser.rs
+++ b/symphonia-bundle-flac/src/parser.rs
@@ -527,13 +527,6 @@ fn strict_frame_header_check(
     header: &FrameHeader,
     last_header: Option<&FrameHeader>,
 ) -> bool {
-    // Sample rate is fixed for the stream.
-    if let Some(sample_rate) = header.sample_rate {
-        if sample_rate != stream_info.sample_rate {
-            return false;
-        }
-    }
-
     // Bits per sample is fixed for the stream.
     if let Some(bps) = header.bits_per_sample {
         if bps != stream_info.bits_per_sample {

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -329,6 +329,11 @@ impl<S: Sample> AudioBuffer<S> {
         &self.spec
     }
 
+    /// Gets a mutable signal specification for the buffer.
+    pub fn spec_mut(&mut self) -> &mut SignalSpec {
+        &mut self.spec
+    }
+
     /// Gets the total capacity of the buffer. The capacity is the maximum number of audio frames
     /// a buffer can store.
     pub fn capacity(&self) -> usize {


### PR DESCRIPTION
FLAC encodes for each frame the sample rate of that frame, it is therefore to be expected that the sample rate changes between frames and is valid per FLAC's test vectors. This patch removes the sample rate check in `strict_frame_header_check` and updates the sample rate in the `SignalSpec` of the `AudioBuffer` after decoding a frame.

Ref: https://github.com/ietf-wg-cellar/flac-test-files/blob/main/uncommon/01%20-%20changing%20samplerate.flac