### PR TITLE
Channel difference handling

### DIFF
--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -256,6 +256,7 @@ mod cpal {
             }
             else {
                 // Use the default config for Windows.
+                // We can't control amount of channels or sample rate in received default config, so process case of difference later.
                 device
                     .default_output_config()
                     .expect("Failed to get the default output config.")
@@ -297,10 +298,9 @@ mod cpal {
             }
 
             let sample_buf = SampleBuffer::<T>::new(duration, spec);
-
-            let resampler = if spec.rate != config.sample_rate.0 {
-                info!("resampling {} Hz to {} Hz", spec.rate, config.sample_rate.0);
-                Some(Resampler::new(spec, config.sample_rate.0 as usize, duration))
+            let resampler = if spec.rate != config.sample_rate.0 || spec.channels.count() != config.channels as usize {
+                info!("resampling {} Hz ({} channels) to {} Hz ({} channels)", spec.rate, spec.channels.count(), config.sample_rate.0, config.channels);
+                Some(Resampler::new(spec, config.sample_rate.0 as usize, duration, config.channels as usize))
             }
             else {
                 None

--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -298,9 +298,22 @@ mod cpal {
             }
 
             let sample_buf = SampleBuffer::<T>::new(duration, spec);
-            let resampler = if spec.rate != config.sample_rate.0 || spec.channels.count() != config.channels as usize {
-                info!("resampling {} Hz ({} channels) to {} Hz ({} channels)", spec.rate, spec.channels.count(), config.sample_rate.0, config.channels);
-                Some(Resampler::new(spec, config.sample_rate.0 as usize, duration, config.channels as usize))
+            let resampler = if spec.rate != config.sample_rate.0
+                || spec.channels.count() != config.channels as usize
+            {
+                info!(
+                    "resampling {} Hz ({} channels) to {} Hz ({} channels)",
+                    spec.rate,
+                    spec.channels.count(),
+                    config.sample_rate.0,
+                    config.channels
+                );
+                Some(Resampler::new(
+                    spec,
+                    config.sample_rate.0 as usize,
+                    duration,
+                    config.channels as usize,
+                ))
             }
             else {
                 None

--- a/symphonia-play/src/resampler.rs
+++ b/symphonia-play/src/resampler.rs
@@ -53,7 +53,7 @@ where
 
         for (i, frame) in self.interleaved.chunks_exact_mut(num_channels).enumerate() {
             for (ch, s) in frame.iter_mut().enumerate() {
-                *s = self.output.get(ch).map(|x|x[i].into_sample()).unwrap_or(T::MID);
+                *s = self.output.get(ch).map(|x| x[i].into_sample()).unwrap_or(T::MID);
             }
         }
 
@@ -65,7 +65,12 @@ impl<T> Resampler<T>
 where
     T: Sample + FromSample<f32> + IntoSample<f32>,
 {
-    pub fn new(spec: SignalSpec, to_sample_rate: usize, duration: u64, output_channels: usize) -> Self {
+    pub fn new(
+        spec: SignalSpec,
+        to_sample_rate: usize,
+        duration: u64,
+        output_channels: usize,
+    ) -> Self {
         assert!(output_channels > 0);
         let duration = duration as usize;
         let num_channels = spec.channels.count();
@@ -83,7 +88,14 @@ where
 
         let input = vec![Vec::with_capacity(duration); num_channels];
 
-        Self { resampler, input, output, duration, interleaved: Default::default(), output_channels }
+        Self {
+            resampler,
+            input,
+            output,
+            duration,
+            interleaved: Default::default(),
+            output_channels,
+        }
     }
 
     /// Resamples a planar/non-interleaved input.

--- a/symphonia-play/src/resampler.rs
+++ b/symphonia-play/src/resampler.rs
@@ -15,6 +15,7 @@ pub struct Resampler<T> {
     output: Vec<Vec<f32>>,
     interleaved: Vec<T>,
     duration: usize,
+    output_channels: usize,
 }
 
 impl<T> Resampler<T>
@@ -45,13 +46,14 @@ where
         }
 
         // Interleave the planar samples from Rubato.
-        let num_channels = self.output.len();
+        // In some cases amount of channels in audio stream isn't equal to the amount of channels in the output device, so fill excess output channels with default values.
+        let num_channels = self.output_channels;
 
         self.interleaved.resize(num_channels * self.output[0].len(), T::MID);
 
         for (i, frame) in self.interleaved.chunks_exact_mut(num_channels).enumerate() {
             for (ch, s) in frame.iter_mut().enumerate() {
-                *s = self.output[ch][i].into_sample();
+                *s = self.output.get(ch).map(|x|x[i].into_sample()).unwrap_or(T::MID);
             }
         }
 
@@ -63,7 +65,8 @@ impl<T> Resampler<T>
 where
     T: Sample + FromSample<f32> + IntoSample<f32>,
 {
-    pub fn new(spec: SignalSpec, to_sample_rate: usize, duration: u64) -> Self {
+    pub fn new(spec: SignalSpec, to_sample_rate: usize, duration: u64, output_channels: usize) -> Self {
+        assert!(output_channels > 0);
         let duration = duration as usize;
         let num_channels = spec.channels.count();
 
@@ -80,7 +83,7 @@ where
 
         let input = vec![Vec::with_capacity(duration); num_channels];
 
-        Self { resampler, input, output, duration, interleaved: Default::default() }
+        Self { resampler, input, output, duration, interleaved: Default::default(), output_channels }
     }
 
     /// Resamples a planar/non-interleaved input.


### PR DESCRIPTION
On Windows this test player is requesting default audio device instead of requesting device with proper parameters. 
Case with different sample rates in original audio stream and output device already explicitly handled by resampler. 
But case with different amount of channels is not, so this leads to awful audio corruption and audio speedup/audio slowdown, for example, in case of two channels in input audio stream and 8 channels in output device audiostream (and in reversal).
This pull request makes resampler fill bytes, corresponded to unused channels, in interleaved buffer with MID value, so everything goes in proper place.
This would be useful for anybody who will use this player as example for their projects or for easier testing of library on different configurations for Windows developers.