### PR TITLE
chore: Update `bitflags` to 2.6.0

### DIFF
--- a/symphonia-core/Cargo.toml
+++ b/symphonia-core/Cargo.toml
@@ -29,7 +29,7 @@ opt-simd = [
 
 [dependencies]
 arrayvec = "0.7.1"
-bitflags = "1.2.1"
+bitflags = "2.6.0"
 bytemuck = "1.7"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -32,7 +32,7 @@ bitflags! {
     /// The first 18 defined channels are guaranteed to be identical to those specified by
     /// Microsoft's WAVEFORMATEXTENSIBLE structure. Channels after 18 are defined by Symphonia and
     /// no order is guaranteed.
-    #[derive(Default)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Channels: u32 {
         /// Front-left (left) or the Mono channel.
         const FRONT_LEFT         = 0x0000_0001;
@@ -90,40 +90,18 @@ bitflags! {
 }
 
 /// An iterator over individual channels within a `Channels` bitmask.
-pub struct ChannelsIter {
-    channels: Channels,
-}
-
-impl Iterator for ChannelsIter {
-    type Item = Channels;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if !self.channels.is_empty() {
-            let channel = Channels::from_bits_truncate(1 << self.channels.bits.trailing_zeros());
-            self.channels ^= channel;
-            Some(channel)
-        }
-        else {
-            None
-        }
-    }
-}
+pub type ChannelsIter = bitflags::iter::Iter<Channels>;
 
 impl Channels {
     /// Gets the number of channels.
     pub fn count(self) -> usize {
-        self.bits.count_ones() as usize
-    }
-
-    /// Gets an iterator over individual channels.
-    pub fn iter(&self) -> ChannelsIter {
-        ChannelsIter { channels: *self }
+        self.bits().count_ones() as usize
     }
 }
 
 impl fmt::Display for Channels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#032b}", self.bits)
+        write!(f, "{:#032b}", self.bits())
     }
 }
 


### PR DESCRIPTION
Since the `Channels` bitflags struct is part of the public API, this is a breaking change.

I've removed the `ChannelsIter` and `iter` method in favor of the bitflags-provided `iter` method (which uses its own iterator type)