### PR TITLE
Update basic-interleaved.rs

### DIFF
--- a/symphonia/examples/basic-interleaved.rs
+++ b/symphonia/examples/basic-interleaved.rs
@@ -77,10 +77,10 @@ fn main() {
                     let spec = *audio_buf.spec();
 
                     // Get the capacity of the decoded buffer. Note: This is capacity, not length!
-                    let duration = audio_buf.capacity() as u64;
+                    let buffer_capacity = audio_buf.capacity() as u64;
 
                     // Create the f32 sample buffer.
-                    sample_buf = Some(SampleBuffer::<f32>::new(duration, spec));
+                    sample_buf = Some(SampleBuffer::<f32>::new(buffer_capacity, spec));
                 }
 
                 // Copy the decoded audio buffer into the sample buffer in an interleaved format.


### PR DESCRIPTION
Changed variable name for clarity. Naming the capacity of the buffer "duration" while also trying to clarify it is not the duration of the file is a bit confusing for new learners, especially given the complexity of Symphonia.