### PR TITLE
isomp4: fix zero track duration for fragmented mp4

### DIFF
--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -56,7 +56,7 @@ impl TrackState {
 
         track
             .with_time_base(TimeBase::new(1, trak.mdia.mdhd.timescale))
-            .with_num_frames(trak.mdia.mdhd.duration);
+            .with_num_frames(trak.duration);
 
         track
     }
@@ -523,8 +523,9 @@ impl FormatReader for IsoMp4Reader<'_> {
             }
             else {
                 // No more segments. If the stream is unseekable, it may be the case that there are
-                // more segments coming. Iterate atoms until a new segment is found or the
-                // end-of-stream is reached.
+                // more segments coming. If the stream is seekable it might be fragmented and no segments are found in
+                // the moov atom. Iterate atoms until a new segment is found or the
+                // end-of-stream is reached
                 if !self.try_read_more_segments()? {
                     return Ok(None);
                 }

--- a/symphonia-format-isomp4/src/stream.rs
+++ b/symphonia-format-isomp4/src/stream.rs
@@ -146,7 +146,7 @@ impl StreamSegment for MoofSegment {
             }
 
             // If a track does NOT end in this segment, then this cannot be the last segment.
-            if seq.first_ts + seq.total_sample_duration < trak.mdia.mdhd.duration {
+            if seq.first_ts + seq.total_sample_duration < trak.duration {
                 return false;
             }
         }
@@ -349,7 +349,7 @@ impl StreamSegment for MoovSegment {
     fn all_tracks_ended(&self) -> bool {
         // If a track does not end in this segment, then this cannot be the last segment.
         for trak in &self.moov.traks {
-            if trak.mdia.minf.stbl.stts.total_duration < trak.mdia.mdhd.duration {
+            if trak.mdia.minf.stbl.stts.total_duration < trak.duration {
                 return false;
             }
         }


### PR DESCRIPTION
trak.mdia.mdhd.duration sometimes is 0 for fragmented mp4.
There are two files from Dolby Vision for which video packets cannot be extracted because of that:
- iOS_P5_GlassBlowing2_3840x2160@59.94fps_15200kbps.mp4
- P81_GlassBlowing2_3840x2160@59.94fps_15200kbps_fmp4.mp4

Solution: take duration from trak.tkhd.duration
Please review.