### PR TITLE
core: rename CODEC_ID_NULL and other constants to be unique

### DIFF
--- a/symphonia-core/src/codecs/audio.rs
+++ b/symphonia-core/src/codecs/audio.rs
@@ -29,11 +29,11 @@ use crate::formats::Packet;
 pub struct AudioCodecId(u32);
 
 /// Null audio codec ID
-pub const CODEC_ID_NULL: AudioCodecId = AudioCodecId(0x0);
+pub const CODEC_ID_NULL_AUDIO: AudioCodecId = AudioCodecId(0x0);
 
 impl Default for AudioCodecId {
     fn default() -> Self {
-        CODEC_ID_NULL
+        CODEC_ID_NULL_AUDIO
     }
 }
 
@@ -102,7 +102,7 @@ pub struct AudioCodecParameters {
 impl AudioCodecParameters {
     pub fn new() -> AudioCodecParameters {
         AudioCodecParameters {
-            codec: CODEC_ID_NULL,
+            codec: CODEC_ID_NULL_AUDIO,
             profile: None,
             sample_rate: None,
             sample_format: None,
@@ -396,9 +396,9 @@ pub mod well_known {
     /// Lossless Digital Audio Codec (LDAC)
     pub const CODEC_ID_LDAC: AudioCodecId = AudioCodecId(0x1018);
     /// Bink Audio
-    pub const CODEC_ID_BINK: AudioCodecId = AudioCodecId(0x1019);
+    pub const CODEC_ID_BINK_AUDIO: AudioCodecId = AudioCodecId(0x1019);
     /// Smacker Audio
-    pub const CODEC_ID_SMACKER: AudioCodecId = AudioCodecId(0x1020);
+    pub const CODEC_ID_SMACKER_AUDIO: AudioCodecId = AudioCodecId(0x1020);
 
     // Compressed lossless audio codecs
     //---------------------------------

--- a/symphonia-core/src/codecs/subtitle.rs
+++ b/symphonia-core/src/codecs/subtitle.rs
@@ -28,7 +28,7 @@ use crate::subtitle::GenericSubtitleBufferRef;
 pub struct SubtitleCodecId(u32);
 
 /// Null subtitle codec ID
-pub const CODEC_ID_NULL: SubtitleCodecId = SubtitleCodecId(0x0);
+pub const CODEC_ID_NULL_SUBTITLE: SubtitleCodecId = SubtitleCodecId(0x0);
 
 impl SubtitleCodecId {
     /// Create a new subtitle codec ID from a FourCC.
@@ -40,7 +40,7 @@ impl SubtitleCodecId {
 
 impl Default for SubtitleCodecId {
     fn default() -> Self {
-        CODEC_ID_NULL
+        CODEC_ID_NULL_SUBTITLE
     }
 }
 
@@ -67,7 +67,7 @@ pub struct SubtitleCodecParameters {
 
 impl SubtitleCodecParameters {
     pub fn new() -> SubtitleCodecParameters {
-        SubtitleCodecParameters { codec: CODEC_ID_NULL, extra_data: None }
+        SubtitleCodecParameters { codec: CODEC_ID_NULL_SUBTITLE, extra_data: None }
     }
 
     /// Provide the `VideoCodecId`.

--- a/symphonia-core/src/codecs/video.rs
+++ b/symphonia-core/src/codecs/video.rs
@@ -25,11 +25,11 @@ use crate::common::FourCc;
 pub struct VideoCodecId(u32);
 
 /// Null video codec ID
-pub const CODEC_ID_NULL: VideoCodecId = VideoCodecId(0x0);
+pub const CODEC_ID_NULL_VIDEO: VideoCodecId = VideoCodecId(0x0);
 
 impl Default for VideoCodecId {
     fn default() -> Self {
-        CODEC_ID_NULL
+        CODEC_ID_NULL_VIDEO
     }
 }
 
@@ -73,7 +73,7 @@ pub struct VideoCodecParameters {
 impl VideoCodecParameters {
     pub fn new() -> VideoCodecParameters {
         VideoCodecParameters {
-            codec: CODEC_ID_NULL,
+            codec: CODEC_ID_NULL_VIDEO,
             profile: None,
             level: None,
             width: None,
@@ -157,9 +157,9 @@ pub mod well_known {
     // RAD Games Tools (Epic Games Tools) codecs
 
     /// Bink Video
-    pub const CODEC_ID_BINK: VideoCodecId = VideoCodecId(0x200);
+    pub const CODEC_ID_BINK_VIDEO: VideoCodecId = VideoCodecId(0x200);
     /// Smacker Video
-    pub const CODEC_ID_SMACKER: VideoCodecId = VideoCodecId(0x201);
+    pub const CODEC_ID_SMACKER_VIDEO: VideoCodecId = VideoCodecId(0x201);
 
     /// Cinepak
     pub const CODEC_ID_CINEPAK: VideoCodecId = VideoCodecId(0x300);

--- a/symphonia-core/src/formats/mod.rs
+++ b/symphonia-core/src/formats/mod.rs
@@ -369,13 +369,13 @@ pub trait FormatReader: Send + Sync {
         // Find the first track matching the desired track type with a known codec.
         self.tracks().iter().find(|track| match &track.codec_params {
             Some(CodecParameters::Audio(params)) if track_type == TrackType::Audio => {
-                params.codec != audio::CODEC_ID_NULL
+                params.codec != audio::CODEC_ID_NULL_AUDIO
             }
             Some(CodecParameters::Video(params)) if track_type == TrackType::Video => {
-                params.codec != video::CODEC_ID_NULL
+                params.codec != video::CODEC_ID_NULL_VIDEO
             }
             Some(CodecParameters::Subtitle(params)) if track_type == TrackType::Subtitle => {
-                params.codec != subtitle::CODEC_ID_NULL
+                params.codec != subtitle::CODEC_ID_NULL_SUBTITLE
             }
             _ => false,
         })

--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -84,7 +84,7 @@ impl EsdsAtom {
     /// If the elementary stream descriptor describes an audio stream, populate the provided
     /// audio codec parameters.
     pub fn fill_audio_codec_params(&self, codec_params: &mut AudioCodecParameters) -> Result<()> {
-        use symphonia_core::codecs::audio::CODEC_ID_NULL;
+        use symphonia_core::codecs::audio::CODEC_ID_NULL_AUDIO;
 
         match get_codec_id_from_object_type(self.descriptor.dec_config.object_type_indication) {
             Some(CodecId::Audio(id)) => {
@@ -97,7 +97,7 @@ impl EsdsAtom {
             }
             None => {
                 // Unknown object type indication.
-                codec_params.for_codec(CODEC_ID_NULL);
+                codec_params.for_codec(CODEC_ID_NULL_AUDIO);
             }
         }
 
@@ -111,7 +111,7 @@ impl EsdsAtom {
     /// If the elementary stream descriptor describes an video stream, populate the provided
     /// video codec parameters.
     pub fn fill_video_codec_params(&self, codec_params: &mut VideoCodecParameters) -> Result<()> {
-        use symphonia_core::codecs::video::CODEC_ID_NULL;
+        use symphonia_core::codecs::video::CODEC_ID_NULL_VIDEO;
 
         match get_codec_id_from_object_type(self.descriptor.dec_config.object_type_indication) {
             Some(CodecId::Video(id)) => {
@@ -124,7 +124,7 @@ impl EsdsAtom {
             }
             None => {
                 // Unknown object type indication.
-                codec_params.for_codec(CODEC_ID_NULL);
+                codec_params.for_codec(CODEC_ID_NULL_VIDEO);
             }
         }
 

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -19,7 +19,7 @@ use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_S8, CODEC_ID_PCM_U8
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U16BE, CODEC_ID_PCM_U16LE};
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U24BE, CODEC_ID_PCM_U24LE};
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U32BE, CODEC_ID_PCM_U32LE};
-use symphonia_core::codecs::audio::{AudioCodecId, AudioCodecParameters, CODEC_ID_NULL};
+use symphonia_core::codecs::audio::{AudioCodecId, AudioCodecParameters, CODEC_ID_NULL_AUDIO};
 use symphonia_core::codecs::subtitle::well_known::CODEC_ID_MOV_TEXT;
 use symphonia_core::codecs::subtitle::SubtitleCodecParameters;
 use symphonia_core::codecs::video::VideoCodecParameters;
@@ -249,7 +249,7 @@ pub struct AudioSampleEntry {
 fn is_pcm_codec(atype: AtomType) -> bool {
     // PCM data in version 0 and 1 is signalled by the sample entry atom type. In version 2, the
     // atom type for PCM data is always LPCM.
-    atype == AtomType::AudioSampleEntryLpcm || pcm_codec_id(atype) != CODEC_ID_NULL
+    atype == AtomType::AudioSampleEntryLpcm || pcm_codec_id(atype) != CODEC_ID_NULL_AUDIO
 }
 
 /// Gets the PCM codec from the sample entry atom type for version 0 and 1 sample entries.
@@ -262,7 +262,7 @@ fn pcm_codec_id(atype: AtomType) -> AudioCodecId {
         AtomType::AudioSampleEntryS32 => CODEC_ID_PCM_S32LE,
         AtomType::AudioSampleEntryF32 => CODEC_ID_PCM_F32LE,
         AtomType::AudioSampleEntryF64 => CODEC_ID_PCM_F64LE,
-        _ => CODEC_ID_NULL,
+        _ => CODEC_ID_NULL_AUDIO,
     }
 }
 
@@ -295,7 +295,7 @@ fn lpcm_codec_id(bits_per_sample: u32, lpcm_flags: u32) -> AudioCodecId {
             64 if is_big_endian => CODEC_ID_PCM_F64BE,
             32 => CODEC_ID_PCM_F32LE,
             64 => CODEC_ID_PCM_F64LE,
-            _ => CODEC_ID_NULL,
+            _ => CODEC_ID_NULL_AUDIO,
         }
     }
     else {
@@ -310,7 +310,7 @@ fn lpcm_codec_id(bits_per_sample: u32, lpcm_flags: u32) -> AudioCodecId {
                 16 => CODEC_ID_PCM_S16LE,
                 24 => CODEC_ID_PCM_S24LE,
                 32 => CODEC_ID_PCM_S32LE,
-                _ => CODEC_ID_NULL,
+                _ => CODEC_ID_NULL_AUDIO,
             }
         }
         else {
@@ -323,7 +323,7 @@ fn lpcm_codec_id(bits_per_sample: u32, lpcm_flags: u32) -> AudioCodecId {
                 16 => CODEC_ID_PCM_U16LE,
                 24 => CODEC_ID_PCM_U24LE,
                 32 => CODEC_ID_PCM_U32LE,
-                _ => CODEC_ID_NULL,
+                _ => CODEC_ID_NULL_AUDIO,
             }
         }
     }
@@ -481,7 +481,7 @@ fn read_audio_sample_entry<B: ReadBytes>(
             // This is only valid if this is a PCM codec.
             let codec_id = lpcm_codec_id(bits_per_sample, lpcm_flags);
 
-            if is_pcm_codec && codec_id != CODEC_ID_NULL {
+            if is_pcm_codec && codec_id != CODEC_ID_NULL_AUDIO {
                 // Like version 1, the new fields describe the PCM sample format and supersede the
                 // original version 0 fields.
                 Some(AudioCodecSpecific::Pcm(Pcm {


### PR DESCRIPTION
Using CODEC_ID_NULL from both audio and video in the same file is not quite convenient and  requires prefixes.
Unique names also remove c-bindings errors