### PR TITLE
Convert VideoCodecParameters.extra_data to vector

### DIFF
--- a/symphonia-common/src/mpeg/video/mod.rs
+++ b/symphonia-common/src/mpeg/video/mod.rs
@@ -76,3 +76,37 @@ impl HEVCDecoderConfigurationRecord {
         })
     }
 }
+
+#[derive(Debug, Default)]
+pub struct DOVIDecoderConfigurationRecord {
+    pub dv_version_major: u8,
+    pub dv_version_minor: u8,
+    pub dv_profile: u8,
+    pub dv_level: u8,
+    pub rpu_present_flag: bool,
+    pub el_present_flag: bool,
+    pub bl_present_flag: bool,
+    pub dv_bl_signal_compatibility_id: u8,
+}
+
+impl DOVIDecoderConfigurationRecord {
+    pub fn read(buf: &[u8]) -> Result<Self> {
+        let mut br = BitReaderLtr::new(buf);
+
+        // Parse the DOVIDecoderConfigurationRecord, point 3.2 from
+        // https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby_vision_bitstreams_within_the_iso_base_media_file_format_dec2017.pdf
+
+        let config = DOVIDecoderConfigurationRecord {
+            dv_version_major: br.read_bits_leq32(8)? as u8,
+            dv_version_minor: br.read_bits_leq32(8)? as u8,
+            dv_profile: br.read_bits_leq32(7)? as u8,
+            dv_level: br.read_bits_leq32(6)? as u8,
+            rpu_present_flag: br.read_bool()?,
+            el_present_flag: br.read_bool()?,
+            bl_present_flag: br.read_bool()?,
+            dv_bl_signal_compatibility_id: br.read_bits_leq32(4)? as u8,
+        };
+
+        Ok(config)
+    }
+}

--- a/symphonia-core/src/codecs/video.rs
+++ b/symphonia-core/src/codecs/video.rs
@@ -53,6 +53,29 @@ impl fmt::Display for VideoCodecId {
     }
 }
 
+/// An `VideoExtraDataId` is a unique identifier used to identify a specific video extra data.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VideoExtraDataId(u32);
+
+/// Null video extra data ID.
+pub const VIDEO_EXTRA_DATA_ID_NULL: VideoExtraDataId = VideoExtraDataId(0x0);
+
+impl Default for VideoExtraDataId {
+    fn default() -> Self {
+        VIDEO_EXTRA_DATA_ID_NULL
+    }
+}
+
+/// Extra data for a video codec.
+#[derive(Clone, Debug, Default)]
+pub struct VideoExtraData {
+    /// The extra data ID.
+    pub id: VideoExtraDataId,
+    /// Extra data (defined by codec)
+    pub data: Box<[u8]>,
+}
+
 /// Codec parameters for video codecs.
 #[derive(Clone, Debug, Default)]
 pub struct VideoCodecParameters {
@@ -67,21 +90,10 @@ pub struct VideoCodecParameters {
     /// Video height.
     pub height: Option<u16>,
     /// Extra data (defined by the codec).
-    pub extra_data: Option<Box<[u8]>>,
+    pub extra_data: Vec<VideoExtraData>,
 }
 
 impl VideoCodecParameters {
-    pub fn new() -> VideoCodecParameters {
-        VideoCodecParameters {
-            codec: CODEC_ID_NULL_VIDEO,
-            profile: None,
-            level: None,
-            width: None,
-            height: None,
-            extra_data: None,
-        }
-    }
-
     /// Provide the `VideoCodecId`.
     pub fn for_codec(&mut self, codec: VideoCodecId) -> &mut Self {
         self.codec = codec;
@@ -112,9 +124,9 @@ impl VideoCodecParameters {
         self
     }
 
-    /// Provide codec extra data.
-    pub fn with_extra_data(&mut self, data: Box<[u8]>) -> &mut Self {
-        self.extra_data = Some(data);
+    /// Adds codec's extra data.
+    pub fn add_extra_data(&mut self, data: VideoExtraData) -> &mut Self {
+        self.extra_data.push(data);
         self
     }
 }
@@ -378,5 +390,27 @@ pub mod well_known {
         pub const CODEC_PROFILE_VC1_MAIN: CodecProfile = CodecProfile(1);
         /// VC-1 Advanced Profile
         pub const CODEC_PROFILE_VC1_ADVANCED: CodecProfile = CodecProfile(2);
+    }
+
+    pub mod extra_data {
+        use crate::codecs::video::VideoExtraDataId;
+
+        /// AVCDecoderConfigurationRecord
+        pub const VIDEO_EXTRA_DATA_ID_AVC_DECODER_CONFIG: VideoExtraDataId = VideoExtraDataId(1);
+
+        /// HEVCDecoderConfigurationRecord
+        pub const VIDEO_EXTRA_DATA_ID_HEVC_DECODER_CONFIG: VideoExtraDataId = VideoExtraDataId(2);
+
+        /// VP9DecoderConfiguration
+        pub const VIDEO_EXTRA_DATA_ID_VP9_DECODER_CONFIG: VideoExtraDataId = VideoExtraDataId(3);
+
+        /// AV1DecoderConfiguration
+        pub const VIDEO_EXTRA_DATA_ID_AV1_DECODER_CONFIG: VideoExtraDataId = VideoExtraDataId(4);
+
+        /// DolbyVisionConfiguration
+        pub const VIDEO_EXTRA_DATA_ID_DOLBY_VISION_CONFIG: VideoExtraDataId = VideoExtraDataId(5);
+
+        /// DolbyVision EL HEVC
+        pub const VIDEO_EXTRA_DATA_ID_DOLBY_VISION_EL_HEVC: VideoExtraDataId = VideoExtraDataId(6);
     }
 }

--- a/symphonia-format-isomp4/src/atoms/alac.rs
+++ b/symphonia-format-isomp4/src/atoms/alac.rs
@@ -6,10 +6,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::codecs::audio::well_known::CODEC_ID_ALAC;
-use symphonia_core::codecs::audio::AudioCodecParameters;
 use symphonia_core::errors::{decode_error, unsupported_error, Result};
 use symphonia_core::io::ReadBytes;
 
+use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
 
 #[allow(dead_code)]
@@ -46,7 +46,8 @@ impl Atom for AlacAtom {
 }
 
 impl AlacAtom {
-    pub fn fill_codec_params(&self, codec_params: &mut AudioCodecParameters) {
-        codec_params.for_codec(CODEC_ID_ALAC).with_extra_data(self.extra_data.clone());
+    pub fn fill_audio_sample_entry(&self, entry: &mut AudioSampleEntry) {
+        entry.codec_id = CODEC_ID_ALAC;
+        entry.extra_data = Some(self.extra_data.clone());
     }
 }

--- a/symphonia-format-isomp4/src/atoms/dac3.rs
+++ b/symphonia-format-isomp4/src/atoms/dac3.rs
@@ -6,10 +6,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::codecs::audio::well_known::CODEC_ID_AC3;
-use symphonia_core::codecs::audio::AudioCodecParameters;
 use symphonia_core::errors::{Error, Result};
 use symphonia_core::io::ReadBytes;
 
+use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
 
 #[allow(dead_code)]
@@ -33,7 +33,8 @@ impl Atom for Dac3Atom {
 }
 
 impl Dac3Atom {
-    pub fn fill_codec_params(&self, codec_params: &mut AudioCodecParameters) {
-        codec_params.for_codec(CODEC_ID_AC3).with_extra_data(self.extra_data.clone());
+    pub fn fill_audio_sample_entry(&self, entry: &mut AudioSampleEntry) {
+        entry.codec_id = CODEC_ID_AC3;
+        entry.extra_data = Some(self.extra_data.clone());
     }
 }

--- a/symphonia-format-isomp4/src/atoms/dec3.rs
+++ b/symphonia-format-isomp4/src/atoms/dec3.rs
@@ -6,10 +6,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::codecs::audio::well_known::CODEC_ID_EAC3;
-use symphonia_core::codecs::audio::AudioCodecParameters;
 use symphonia_core::errors::{Error, Result};
 use symphonia_core::io::ReadBytes;
 
+use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
 
 #[allow(dead_code)]
@@ -33,7 +33,8 @@ impl Atom for Dec3Atom {
 }
 
 impl Dec3Atom {
-    pub fn fill_codec_params(&self, codec_params: &mut AudioCodecParameters) {
-        codec_params.for_codec(CODEC_ID_EAC3).with_extra_data(self.extra_data.clone());
+    pub fn fill_audio_sample_entry(&self, entry: &mut AudioSampleEntry) {
+        entry.codec_id = CODEC_ID_EAC3;
+        entry.extra_data = Some(self.extra_data.clone());
     }
 }

--- a/symphonia-format-isomp4/src/atoms/dovi.rs
+++ b/symphonia-format-isomp4/src/atoms/dovi.rs
@@ -1,0 +1,49 @@
+// Symphonia
+// Copyright (c) 2019-2022 The Project Symphonia Developers.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use symphonia_core::codecs::video::well_known::extra_data::VIDEO_EXTRA_DATA_ID_DOLBY_VISION_CONFIG;
+use symphonia_core::codecs::video::VideoExtraData;
+use symphonia_core::errors::{decode_error, Result};
+use symphonia_core::io::ReadBytes;
+
+use crate::atoms::stsd::VisualSampleEntry;
+use crate::atoms::{Atom, AtomHeader};
+
+const DOVI_CONFIG_SIZE: u64 = 24;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct DoviAtom {
+    extra_data: VideoExtraData,
+}
+
+impl Atom for DoviAtom {
+    fn read<B: ReadBytes>(reader: &mut B, header: AtomHeader) -> Result<Self> {
+        // The Dolby Vision Configuration atom payload (dvvC and dvcC).
+        // Contains DOVIDecoderConfigurationRecord, point 3.2 from
+        // https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby_vision_bitstreams_within_the_iso_base_media_file_format_dec2017.pdf
+        // It should be 24 bytes
+        let len = match header.data_len() {
+            Some(len @ DOVI_CONFIG_SIZE) => len as usize,
+            Some(_) => return decode_error("isomp4 (dvcC/dvvC): atom size is not 24 bytes"),
+            None => return decode_error("isomp4 (dvcC/dvvC): expected atom size to be known"),
+        };
+
+        let dovi_data = VideoExtraData {
+            id: VIDEO_EXTRA_DATA_ID_DOLBY_VISION_CONFIG,
+            data: reader.read_boxed_slice_exact(len)?,
+        };
+
+        Ok(Self { extra_data: dovi_data })
+    }
+}
+
+impl DoviAtom {
+    pub fn fill_video_sample_entry(&self, entry: &mut VisualSampleEntry) {
+        entry.extra_data.push(self.extra_data.clone());
+    }
+}

--- a/symphonia-format-isomp4/src/atoms/hvcc.rs
+++ b/symphonia-format-isomp4/src/atoms/hvcc.rs
@@ -6,19 +6,23 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_common::mpeg::video::HEVCDecoderConfigurationRecord;
+use symphonia_core::codecs::video::well_known::extra_data::VIDEO_EXTRA_DATA_ID_HEVC_DECODER_CONFIG;
 use symphonia_core::codecs::video::well_known::CODEC_ID_HEVC;
-use symphonia_core::codecs::video::VideoCodecParameters;
+use symphonia_core::codecs::video::VideoExtraData;
 use symphonia_core::codecs::CodecProfile;
-use symphonia_core::errors::{Error, Result};
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
+use crate::atoms::stsd::VisualSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
+
+const MAX_ATOM_SIZE: u64 = 1024;
 
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct HvcCAtom {
     /// HEVC extra data (HEVCDecoderConfigurationRecord).
-    extra_data: Box<[u8]>,
+    extra_data: VideoExtraData,
     profile: CodecProfile,
     level: u32,
 }
@@ -26,25 +30,29 @@ pub struct HvcCAtom {
 impl Atom for HvcCAtom {
     fn read<B: ReadBytes>(reader: &mut B, header: AtomHeader) -> Result<Self> {
         // The HEVCConfiguration atom payload is a single HEVCDecoderConfigurationRecord. This record
-        // forms the defacto codec extra data.
-        let len = header
-            .data_len()
-            .ok_or_else(|| Error::DecodeError("isomp4 (hvcC): expected atom size to be known"))?;
+        // forms the defacto codec extra data. It should not exceed 1kb
+        let len = match header.data_len() {
+            Some(len) if len <= MAX_ATOM_SIZE => len as usize,
+            Some(_) => return decode_error("isomp4 (hvcC): atom size is greater than 1kb"),
+            None => return decode_error("isomp4 (hvcC): expected atom size to be known"),
+        };
 
-        let extra_data = reader.read_boxed_slice_exact(len as usize)?;
+        let extra_data = VideoExtraData {
+            id: VIDEO_EXTRA_DATA_ID_HEVC_DECODER_CONFIG,
+            data: reader.read_boxed_slice_exact(len)?,
+        };
 
-        let hevc_config = HEVCDecoderConfigurationRecord::read(&extra_data)?;
+        let hevc_config = HEVCDecoderConfigurationRecord::read(&extra_data.data)?;
 
         Ok(Self { extra_data, profile: hevc_config.profile, level: hevc_config.level })
     }
 }
 
 impl HvcCAtom {
-    pub fn fill_codec_params(&self, codec_params: &mut VideoCodecParameters) {
-        codec_params
-            .for_codec(CODEC_ID_HEVC)
-            .with_profile(self.profile)
-            .with_level(self.level)
-            .with_extra_data(self.extra_data.clone());
+    pub fn fill_video_sample_entry(&self, entry: &mut VisualSampleEntry) {
+        entry.codec_id = CODEC_ID_HEVC;
+        entry.profile = Some(self.profile);
+        entry.level = Some(self.level);
+        entry.extra_data.push(self.extra_data.clone());
     }
 }

--- a/symphonia-format-isomp4/src/atoms/mod.rs
+++ b/symphonia-format-isomp4/src/atoms/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod co64;
 pub(crate) mod ctts;
 pub(crate) mod dac3;
 pub(crate) mod dec3;
+pub(crate) mod dovi;
 pub(crate) mod edts;
 pub(crate) mod elst;
 pub(crate) mod esds;
@@ -61,6 +62,7 @@ pub use co64::Co64Atom;
 pub use ctts::CttsAtom;
 pub use dac3::Dac3Atom;
 pub use dec3::Dec3Atom;
+pub use dovi::DoviAtom;
 pub use edts::EdtsAtom;
 pub use elst::ElstAtom;
 pub use esds::EsdsAtom;
@@ -141,6 +143,7 @@ pub enum AtomType {
     DateTag,
     DescriptionTag,
     DiskNumberTag,
+    DolbyVisionConfiguration,
     Eac3Config,
     Edit,
     EditList,
@@ -250,8 +253,10 @@ impl From<[u8; 4]> for AtomType {
             b"data" => AtomType::MetaTagData,
             b"dfLa" => AtomType::FlacDsConfig,
             b"dOps" => AtomType::OpusDsConfig,
+            b"dvcC" => AtomType::DolbyVisionConfiguration,
             b"dvh1" => AtomType::VisualSampleEntryDvh1,
             b"dvhe" => AtomType::VisualSampleEntryDvhe,
+            b"dvvC" => AtomType::DolbyVisionConfiguration,
             b"edts" => AtomType::Edit,
             b"elst" => AtomType::EditList,
             b"esds" => AtomType::Esds,

--- a/symphonia-format-isomp4/src/atoms/opus.rs
+++ b/symphonia-format-isomp4/src/atoms/opus.rs
@@ -5,10 +5,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::codecs::audio::{well_known::CODEC_ID_OPUS, AudioCodecParameters};
+use symphonia_core::codecs::audio::well_known::CODEC_ID_OPUS;
 use symphonia_core::errors::{decode_error, unsupported_error, Error, Result};
 use symphonia_core::io::ReadBytes;
 
+use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
 
 /// Opus atom.
@@ -64,7 +65,8 @@ impl Atom for OpusAtom {
 }
 
 impl OpusAtom {
-    pub fn fill_codec_params(&self, codec_params: &mut AudioCodecParameters) {
-        codec_params.for_codec(CODEC_ID_OPUS).with_extra_data(self.extra_data.clone());
+    pub fn fill_audio_sample_entry(&self, entry: &mut AudioSampleEntry) {
+        entry.codec_id = CODEC_ID_OPUS;
+        entry.extra_data = Some(self.extra_data.clone());
     }
 }

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -19,7 +19,9 @@ use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_S8, CODEC_ID_PCM_U8
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U16BE, CODEC_ID_PCM_U16LE};
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U24BE, CODEC_ID_PCM_U24LE};
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_U32BE, CODEC_ID_PCM_U32LE};
-use symphonia_core::codecs::audio::{AudioCodecId, AudioCodecParameters, CODEC_ID_NULL_AUDIO};
+use symphonia_core::codecs::audio::{
+    AudioCodecId, AudioCodecParameters, VerificationCheck, CODEC_ID_NULL_AUDIO,
+};
 use symphonia_core::codecs::subtitle::well_known::CODEC_ID_MOV_TEXT;
 use symphonia_core::codecs::subtitle::SubtitleCodecParameters;
 use symphonia_core::codecs::video::{VideoCodecId, VideoCodecParameters, VideoExtraData};
@@ -28,12 +30,10 @@ use symphonia_core::errors::{decode_error, unsupported_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{
-    AlacAtom, Atom, AtomHeader, AtomType, Dac3Atom, Dec3Atom, EsdsAtom, FlacAtom, OpusAtom,
-    WaveAtom,
+    AlacAtom, Atom, AtomHeader, AtomIterator, AtomType, AvcCAtom, Dac3Atom, Dec3Atom, EsdsAtom,
+    FlacAtom, HvcCAtom, OpusAtom, WaveAtom,
 };
 use crate::fp::FpU16;
-
-use super::{AtomIterator, AvcCAtom, HvcCAtom};
 
 /// Sample description atom.
 #[allow(dead_code)]
@@ -111,110 +111,14 @@ impl StsdAtom {
     pub fn make_codec_params(&self) -> Option<CodecParameters> {
         // Audio sample entry.
         match &self.sample_entry {
-            SampleEntry::Audio(entry) => {
-                let mut codec_params = AudioCodecParameters::new();
-
-                // General audio parameters.
-                codec_params.with_sample_rate(entry.sample_rate as u32);
-
-                // Codec-specific parameters.
-                match entry.codec_specific {
-                    Some(AudioCodecSpecific::Esds(ref esds)) => {
-                        // ESDS is not an audio specific atom. Returns an error if not an audio
-                        // elementary stream.
-                        esds.fill_audio_codec_params(&mut codec_params).ok()?;
-                    }
-                    Some(AudioCodecSpecific::Ac3(ref dac3)) => {
-                        dac3.fill_codec_params(&mut codec_params);
-                    }
-                    Some(AudioCodecSpecific::Alac(ref alac)) => {
-                        alac.fill_codec_params(&mut codec_params);
-                    }
-                    Some(AudioCodecSpecific::Eac3(ref dec3)) => {
-                        dec3.fill_codec_params(&mut codec_params);
-                    }
-                    Some(AudioCodecSpecific::Flac(ref flac)) => {
-                        flac.fill_codec_params(&mut codec_params);
-                    }
-                    Some(AudioCodecSpecific::Opus(ref opus)) => {
-                        opus.fill_codec_params(&mut codec_params);
-                    }
-                    Some(AudioCodecSpecific::Mp3) => {
-                        codec_params.for_codec(CODEC_ID_MP3);
-                    }
-                    Some(AudioCodecSpecific::Pcm(ref pcm)) => {
-                        // PCM codecs.
-                        codec_params
-                            .for_codec(pcm.codec_id)
-                            .with_bits_per_coded_sample(pcm.bits_per_coded_sample)
-                            .with_bits_per_sample(pcm.bits_per_sample)
-                            .with_max_frames_per_packet(pcm.frames_per_packet)
-                            .with_channels(pcm.channels.clone());
-                    }
-                    _ => (),
-                }
-
-                Some(CodecParameters::Audio(codec_params))
-            }
-            SampleEntry::Visual(entry) => {
-                let mut codec_params = VideoCodecParameters {
-                    width: Some(entry.width),
-                    height: Some(entry.height),
-                    codec: entry.codec_id,
-                    extra_data: entry.extra_data.clone(),
-                    ..Default::default()
-                };
-
-                if let Some(profile) = entry.profile {
-                    codec_params.with_profile(profile);
-                }
-                if let Some(level) = entry.level {
-                    codec_params.with_level(level);
-                }
-
-                Some(CodecParameters::Video(codec_params))
-            }
+            SampleEntry::Audio(entry) => Some(CodecParameters::Audio(entry.make_codec_params())),
+            SampleEntry::Visual(entry) => Some(CodecParameters::Video(entry.make_codec_params())),
             SampleEntry::Subtitle(entry) => {
-                let mut codec_params = SubtitleCodecParameters::new();
-
-                if let Some(SubtitleCodecSpecific::TimedText) = entry.codec_specific {
-                    codec_params.for_codec(CODEC_ID_MOV_TEXT);
-                }
-
-                Some(CodecParameters::Subtitle(codec_params))
+                Some(CodecParameters::Subtitle(entry.make_codec_params()))
             }
             _ => None,
         }
     }
-}
-
-#[derive(Debug)]
-pub struct Pcm {
-    pub codec_id: AudioCodecId,
-    pub bits_per_sample: u32,
-    pub bits_per_coded_sample: u32,
-    pub frames_per_packet: u64,
-    pub channels: Channels,
-}
-
-#[derive(Debug)]
-pub enum AudioCodecSpecific {
-    /// MPEG Elementary Stream descriptor.
-    Esds(EsdsAtom),
-    /// Dolby Digital
-    Ac3(Dac3Atom),
-    /// Apple Lossless Audio Codec (ALAC).
-    Alac(AlacAtom),
-    /// Dolby Digital Plus
-    Eac3(Dec3Atom),
-    /// Free Lossless Audio Codec (FLAC).
-    Flac(FlacAtom),
-    /// Opus.
-    Opus(OpusAtom),
-    /// MP3.
-    Mp3,
-    /// PCM codecs.
-    Pcm(Pcm),
 }
 
 /// Generic sample entry.
@@ -230,14 +134,35 @@ pub enum SampleEntry {
 
 /// Audio sample entry.
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AudioSampleEntry {
     pub num_channels: u32,
     pub sample_size: u16,
     pub sample_rate: f64,
-    pub codec_specific: Option<AudioCodecSpecific>,
+    pub codec_id: AudioCodecId,
+    pub bits_per_sample: Option<u32>,
+    pub bits_per_coded_sample: Option<u32>,
+    pub frames_per_packet: Option<u64>,
+    pub channels: Option<Channels>,
+    pub verification_check: Option<VerificationCheck>,
+    pub extra_data: Option<Box<[u8]>>,
 }
 
+impl AudioSampleEntry {
+    pub(crate) fn make_codec_params(&self) -> AudioCodecParameters {
+        AudioCodecParameters {
+            codec: self.codec_id,
+            sample_rate: Some(self.sample_rate as u32),
+            bits_per_sample: self.bits_per_sample,
+            bits_per_coded_sample: self.bits_per_coded_sample,
+            channels: self.channels.clone(),
+            max_frames_per_packet: self.frames_per_packet,
+            verification_check: self.verification_check,
+            extra_data: self.extra_data.clone(),
+            ..Default::default()
+        }
+    }
+}
 /// Gets if the sample entry atom is for a PCM codec.
 fn is_pcm_codec(atype: AtomType) -> bool {
     // PCM data in version 0 and 1 is signalled by the sample entry atom type. In version 2, the
@@ -373,45 +298,39 @@ fn read_audio_sample_entry<B: ReadBytes>(
 
     // AudioSampleEntry(V1) portion
 
+    let mut entry = AudioSampleEntry::default();
+
     // The version of the audio sample entry.
     let version = reader.read_be_u16()?;
 
     // Skip revision and vendor.
     reader.ignore_bytes(6)?;
 
-    let mut num_channels = u32::from(reader.read_be_u16()?);
-    let sample_size = reader.read_be_u16()?;
+    entry.num_channels = u32::from(reader.read_be_u16()?);
+    entry.sample_size = reader.read_be_u16()?;
 
     // Skip compression ID and packet size.
     reader.ignore_bytes(4)?;
 
-    let mut sample_rate = f64::from(FpU16::parse_raw(reader.read_be_u32()?));
+    entry.sample_rate = f64::from(FpU16::parse_raw(reader.read_be_u32()?));
 
     let is_pcm_codec = is_pcm_codec(header.atom_type);
 
-    let mut codec_specific = match version {
+    match version {
         0 => {
             // Version 0.
             if is_pcm_codec {
-                let codec_id = pcm_codec_id(header.atom_type);
-                let bits_per_sample = 8 * bytes_per_pcm_sample(codec_id);
+                entry.codec_id = pcm_codec_id(header.atom_type);
+                let bits_per_sample = 8 * bytes_per_pcm_sample(entry.codec_id);
 
                 // Validate the codec-derived bytes-per-sample equals the declared bytes-per-sample.
-                if u32::from(sample_size) != bits_per_sample {
+                if u32::from(entry.sample_size) != bits_per_sample {
                     return decode_error("isomp4: invalid pcm sample size");
                 }
-
-                // The original fields describe the PCM sample format.
-                Some(AudioCodecSpecific::Pcm(Pcm {
-                    codec_id: pcm_codec_id(header.atom_type),
-                    bits_per_sample,
-                    bits_per_coded_sample: bits_per_sample,
-                    frames_per_packet: 1,
-                    channels: pcm_channels(num_channels)?,
-                }))
-            }
-            else {
-                None
+                entry.bits_per_sample = Some(bits_per_sample);
+                entry.bits_per_coded_sample = Some(bits_per_sample);
+                entry.frames_per_packet = Some(1);
+                entry.channels = Some(pcm_channels(entry.num_channels)?);
             }
         }
         1 => {
@@ -432,8 +351,8 @@ fn read_audio_sample_entry<B: ReadBytes>(
             let _ = reader.read_be_u32()?;
 
             if is_pcm_codec {
-                let codec_id = pcm_codec_id(header.atom_type);
-                let codec_bytes_per_sample = bytes_per_pcm_sample(codec_id);
+                entry.codec_id = pcm_codec_id(header.atom_type);
+                let codec_bytes_per_sample = bytes_per_pcm_sample(entry.codec_id);
 
                 // Validate the codec-derived bytes-per-sample equals the declared bytes-per-sample.
                 if bytes_per_audio_sample != codec_bytes_per_sample {
@@ -442,24 +361,18 @@ fn read_audio_sample_entry<B: ReadBytes>(
 
                 // The new fields describe the PCM sample format and supersede the original version
                 // 0 fields.
-                Some(AudioCodecSpecific::Pcm(Pcm {
-                    codec_id,
-                    bits_per_sample: 8 * codec_bytes_per_sample,
-                    bits_per_coded_sample: 8 * codec_bytes_per_sample,
-                    frames_per_packet: 1,
-                    channels: pcm_channels(num_channels)?,
-                }))
-            }
-            else {
-                None
+                entry.bits_per_sample = Some(8 * codec_bytes_per_sample);
+                entry.bits_per_coded_sample = Some(8 * codec_bytes_per_sample);
+                entry.frames_per_packet = Some(1);
+                entry.channels = Some(pcm_channels(entry.num_channels)?);
             }
         }
         2 => {
             // Version 2.
             reader.ignore_bytes(4)?;
 
-            sample_rate = reader.read_be_f64()?;
-            num_channels = reader.read_be_u32()?;
+            entry.sample_rate = reader.read_be_f64()?;
+            entry.num_channels = reader.read_be_u32()?;
 
             if reader.read_be_u32()? != 0x7f00_0000 {
                 return decode_error("isomp4: audio sample entry v2 reserved must be 0x7f00_0000");
@@ -472,21 +385,15 @@ fn read_audio_sample_entry<B: ReadBytes>(
             let lpcm_frames_per_packet = reader.read_be_u32()?;
 
             // This is only valid if this is a PCM codec.
-            let codec_id = lpcm_codec_id(bits_per_sample, lpcm_flags);
+            entry.codec_id = lpcm_codec_id(bits_per_sample, lpcm_flags);
 
-            if is_pcm_codec && codec_id != CODEC_ID_NULL_AUDIO {
+            if is_pcm_codec && entry.codec_id != CODEC_ID_NULL_AUDIO {
                 // Like version 1, the new fields describe the PCM sample format and supersede the
                 // original version 0 fields.
-                Some(AudioCodecSpecific::Pcm(Pcm {
-                    codec_id,
-                    bits_per_sample,
-                    bits_per_coded_sample: bits_per_sample,
-                    frames_per_packet: u64::from(lpcm_frames_per_packet),
-                    channels: lpcm_channels(num_channels)?,
-                }))
-            }
-            else {
-                None
+                entry.bits_per_sample = Some(bits_per_sample);
+                entry.bits_per_coded_sample = Some(bits_per_sample);
+                entry.frames_per_packet = Some(u64::from(lpcm_frames_per_packet));
+                entry.channels = Some(lpcm_channels(entry.num_channels)?);
             }
         }
         _ => {
@@ -499,65 +406,34 @@ fn read_audio_sample_entry<B: ReadBytes>(
     while let Some(entry_header) = iter.next()? {
         match entry_header.atom_type {
             AtomType::Esds => {
-                // MP4A/ESDS codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryMp4a || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Esds(iter.read_atom::<EsdsAtom>()?));
+                let atom = iter.read_atom::<EsdsAtom>()?;
+                atom.fill_audio_sample_entry(&mut entry)?;
             }
             AtomType::Ac3Config => {
-                // Ac3 codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryAc3 || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Ac3(iter.read_atom::<Dac3Atom>()?));
+                let atom = iter.read_atom::<Dac3Atom>()?;
+                atom.fill_audio_sample_entry(&mut entry);
             }
             AtomType::AudioSampleEntryAlac => {
-                // ALAC codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryAlac || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Alac(iter.read_atom::<AlacAtom>()?));
+                let atom = iter.read_atom::<AlacAtom>()?;
+                atom.fill_audio_sample_entry(&mut entry);
             }
             AtomType::Eac3Config => {
-                // Eac3 codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryEc3 || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Eac3(iter.read_atom::<Dec3Atom>()?));
+                let atom = iter.read_atom::<Dec3Atom>()?;
+                atom.fill_audio_sample_entry(&mut entry);
             }
             AtomType::FlacDsConfig => {
-                // FLAC codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryFlac || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Flac(iter.read_atom::<FlacAtom>()?));
+                let atom = iter.read_atom::<FlacAtom>()?;
+                atom.fill_audio_sample_entry(&mut entry);
             }
             AtomType::OpusDsConfig => {
-                // Opus codec-specific atom.
-                if header.atom_type != AtomType::AudioSampleEntryOpus || codec_specific.is_some() {
-                    return decode_error("isomp4: invalid sample entry");
-                }
-
-                codec_specific = Some(AudioCodecSpecific::Opus(iter.read_atom::<OpusAtom>()?));
+                let atom = iter.read_atom::<OpusAtom>()?;
+                atom.fill_audio_sample_entry(&mut entry);
             }
             AtomType::AudioSampleEntryQtWave => {
                 // The QuickTime WAVE (aka. siDecompressionParam) atom may contain many different
                 // types of sub-atoms to store decoder parameters.
-                let wave = iter.read_atom::<WaveAtom>()?;
-
-                if let Some(esds) = wave.esds {
-                    if codec_specific.is_some() {
-                        return decode_error("isomp4: invalid sample entry");
-                    }
-
-                    codec_specific = Some(AudioCodecSpecific::Esds(esds));
-                }
+                let atom = iter.read_atom::<WaveAtom>()?;
+                atom.fill_audio_sample_entry(&mut entry)?;
             }
             _ => {
                 debug!("unknown audio sample entry sub-atom: {:?}.", entry_header.atom_type());
@@ -567,19 +443,10 @@ fn read_audio_sample_entry<B: ReadBytes>(
 
     // A MP3 sample entry has no codec-specific atom.
     if header.atom_type == AtomType::AudioSampleEntryMp3 {
-        if codec_specific.is_some() {
-            return decode_error("isomp4: invalid sample entry");
-        }
-
-        codec_specific = Some(AudioCodecSpecific::Mp3);
+        entry.codec_id = CODEC_ID_MP3;
     }
 
-    Ok(SampleEntry::Audio(AudioSampleEntry {
-        num_channels,
-        sample_size,
-        sample_rate,
-        codec_specific,
-    }))
+    Ok(SampleEntry::Audio(entry))
 }
 
 /// Visual sample entry.
@@ -597,6 +464,27 @@ pub struct VisualSampleEntry {
     pub profile: Option<CodecProfile>,
     pub level: Option<u32>,
     pub extra_data: Vec<VideoExtraData>,
+}
+
+impl VisualSampleEntry {
+    pub(crate) fn make_codec_params(&self) -> VideoCodecParameters {
+        let mut codec_params = VideoCodecParameters {
+            width: Some(self.width),
+            height: Some(self.height),
+            codec: self.codec_id,
+            extra_data: self.extra_data.clone(),
+            ..Default::default()
+        };
+
+        if let Some(profile) = self.profile {
+            codec_params.with_profile(profile);
+        }
+        if let Some(level) = self.level {
+            codec_params.with_level(level);
+        }
+
+        codec_params
+    }
 }
 
 fn read_visual_sample_entry<B: ReadBytes>(
@@ -684,6 +572,18 @@ pub struct SubtitleSampleEntry {
     btrt: Option<BtrtAtom>,
     txtc: Option<TxtcAtom>,
     codec_specific: Option<SubtitleCodecSpecific>,
+}
+
+impl SubtitleSampleEntry {
+    pub(crate) fn make_codec_params(&self) -> SubtitleCodecParameters {
+        let mut codec_params = SubtitleCodecParameters::new();
+
+        if let Some(SubtitleCodecSpecific::TimedText) = self.codec_specific {
+            codec_params.for_codec(CODEC_ID_MOV_TEXT);
+        }
+
+        codec_params
+    }
 }
 
 fn read_subtitle_sample_entry<B: ReadBytes>(

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -30,8 +30,8 @@ use symphonia_core::errors::{decode_error, unsupported_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{
-    AlacAtom, Atom, AtomHeader, AtomIterator, AtomType, AvcCAtom, Dac3Atom, Dec3Atom, EsdsAtom,
-    FlacAtom, HvcCAtom, OpusAtom, WaveAtom,
+    AlacAtom, Atom, AtomHeader, AtomIterator, AtomType, AvcCAtom, Dac3Atom, Dec3Atom, DoviAtom,
+    EsdsAtom, FlacAtom, HvcCAtom, OpusAtom, WaveAtom,
 };
 use crate::fp::FpU16;
 
@@ -548,6 +548,10 @@ fn read_visual_sample_entry<B: ReadBytes>(
             }
             AtomType::HevcConfiguration => {
                 let atom = iter.read_atom::<HvcCAtom>()?;
+                atom.fill_video_sample_entry(&mut entry);
+            }
+            AtomType::DolbyVisionConfiguration => {
+                let atom = iter.read_atom::<DoviAtom>()?;
                 atom.fill_video_sample_entry(&mut entry);
             }
             _ => {

--- a/symphonia-format-isomp4/src/atoms/wave.rs
+++ b/symphonia-format-isomp4/src/atoms/wave.rs
@@ -8,9 +8,8 @@
 use symphonia_core::errors::Result;
 use symphonia_core::io::ReadBytes;
 
-use crate::atoms::{Atom, AtomHeader, EsdsAtom};
-
-use super::{AtomIterator, AtomType};
+use crate::atoms::stsd::AudioSampleEntry;
+use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, EsdsAtom};
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -31,5 +30,15 @@ impl Atom for WaveAtom {
         }
 
         Ok(WaveAtom { esds })
+    }
+}
+
+impl WaveAtom {
+    pub fn fill_audio_sample_entry(&self, entry: &mut AudioSampleEntry) -> Result<()> {
+        if let Some(esds) = &self.esds {
+            esds.fill_audio_sample_entry(entry)?;
+        }
+
+        Ok(())
     }
 }

--- a/symphonia-format-mkv/src/codecs.rs
+++ b/symphonia-format-mkv/src/codecs.rs
@@ -138,6 +138,12 @@ fn make_video_codec_params(
         codec_params.add_extra_data(VideoExtraData { id: extra_data_id, data: codec_private });
     }
 
+    for block in track.block_addition_mappings {
+        if let Some(extra_data) = block.extra_data {
+            codec_params.add_extra_data(extra_data);
+        }
+    }
+
     Ok(Some(CodecParameters::Video(codec_params)))
 }
 

--- a/symphonia-format-mkv/src/element_ids.rs
+++ b/symphonia-format-mkv/src/element_ids.rs
@@ -53,7 +53,9 @@ pub enum ElementType {
     BlockAdditions,
     BlockMore,
     BlockAddId,
+    BlockAddIdType,
     BlockAdditional,
+    BlockAdditionMapping,
     BlockDuration,
     ReferenceBlock,
     DiscardPadding,
@@ -93,6 +95,7 @@ pub enum ElementType {
     DisplayHeight,
     DisplayUnit,
     AspectRatioType,
+    DolbyVisionConfiguration,
     Audio,
     SamplingFrequency,
     OutputSamplingFrequency,
@@ -218,7 +221,9 @@ lazy_static! {
         elems.insert(0x75A1, (Type::Master, ElementType::BlockAdditions));
         elems.insert(0xA6, (Type::Master, ElementType::BlockMore));
         elems.insert(0xEE, (Type::Unsigned, ElementType::BlockAddId));
+        elems.insert(0x41E7, (Type::String, ElementType::BlockAddIdType));
         elems.insert(0xA5, (Type::Binary, ElementType::BlockAdditional));
+        elems.insert(0x41E4, (Type::Binary, ElementType::BlockAdditionMapping));
         elems.insert(0x9B, (Type::Unsigned, ElementType::BlockDuration));
         elems.insert(0xFB, (Type::Signed, ElementType::ReferenceBlock));
         elems.insert(0x75A2, (Type::Signed, ElementType::DiscardPadding));
@@ -258,6 +263,7 @@ lazy_static! {
         elems.insert(0x54BA, (Type::Unsigned, ElementType::DisplayHeight));
         elems.insert(0x54B2, (Type::Unsigned, ElementType::DisplayUnit));
         elems.insert(0x54B3, (Type::Unsigned, ElementType::AspectRatioType));
+        elems.insert(0x41ED, (Type::Binary, ElementType::DolbyVisionConfiguration));
         elems.insert(0xE1, (Type::Master, ElementType::Audio));
         elems.insert(0xB5, (Type::Float, ElementType::SamplingFrequency));
         elems.insert(0x78B5, (Type::Float, ElementType::OutputSamplingFrequency));


### PR DESCRIPTION
it is based on constants renaming commit from PR #322
This PR is to get early feedback, mkv changes are not finished, I will add another commit later
Notes: 
- used let mut VideoCodecParameters and write values directly into it, instead of creating many temp variables and then copy them to VideoCodecParameters. This is not following other code pattern, but with the growing number of variables can be more suitable/readable. Please let me know your opinion.
- removed VisualCodecSpecific, initially this followed AudioCodecSpecific, but I'm not sure it is needed. VideoCodecParameters should have codec_id_tag (FourCC code) where VisualCodecSpecific variations can be stored.



