### PR TITLE
isomp4 take track id from the media source

### DIFF
--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -235,7 +235,11 @@ impl<'s> IsoMp4Reader<'s> {
         }
 
         // Instantiate a `TrackState` for each track in the media.
-        let track_states = (0..moov.traks.len()).map(TrackState::new).collect::<Vec<TrackState>>();
+        let track_states = moov
+            .traks
+            .iter()
+            .map(|trak| TrackState::new(trak.tkhd.id as usize))
+            .collect::<Vec<TrackState>>();
 
         // Instantiate a `Track` for all track states above.
         let tracks = track_states


### PR DESCRIPTION
for isomp4 track id is assigned sequentially from 0, while track id for mkv is taken from the media source.
According to description from the core Track - id should be taken from the media source. This PR fixes track id for mp4.
