### PR TITLE
riff: fix parsing ffmpeg wave stdout output

### DIFF
--- a/symphonia-format-riff/src/common.rs
+++ b/symphonia-format-riff/src/common.rs
@@ -92,8 +92,8 @@ impl<T: ParseChunkTag> ChunksReader<T> {
             // input, it may overflow when if added to anything.
             if self.len - self.consumed < len {
                 // When ffmpeg encodes wave to stdout the riff (parent) and data chunk lengths are
-                // (2^32)-1 since the size can't be known ahead of time.
-                if !(self.len == len && len == u32::MAX) {
+                // (2^32)-1 since the size can't be known ahead of time. Parent length was reduced by 4 to read "form type"
+                if !(self.len + 4 == u32::MAX && len == u32::MAX) {
                     debug!(
                         "chunk length of {} exceeds parent (list) chunk length",
                         String::from_utf8_lossy(&tag)


### PR DESCRIPTION
Adding back 4 bytes for parent length comparison with u32:MAX as it was reduced by 4 bytes in commit f72ac415f6910e56660247882d78835b81ae6a7e

This fixes` symphonia-check some.mp3` which currently returns error:

> Test interrupted by error: malformed stream: riff: chunk length exceeds parent (list) chunk length