### PR TITLE
flac: normalize the frame's sample rate when reading it from a single byte

### DIFF
--- a/symphonia-bundle-flac/src/frame.rs
+++ b/symphonia-bundle-flac/src/frame.rs
@@ -165,7 +165,7 @@ pub fn read_frame_header<B: ReadBytes>(reader: &mut B, sync: u16) -> Result<Fram
         0x9 => Some(44_100),
         0xa => Some(48_000),
         0xb => Some(96_000),
-        0xc => Some(u32::from(reader_crc8.read_u8()?)),
+        0xc => Some(u32::from(reader_crc8.read_u8()?) * 1000),
         0xd => Some(u32::from(reader_crc8.read_be_u16()?)),
         0xe => Some(u32::from(reader_crc8.read_be_u16()?) * 10),
         _ => {


### PR DESCRIPTION
Fixes #293

Convert the value 192 to 192_000.
Without this conversion, the FLAC parser’s resync() method cannot find a valid frame and attempts to seek beyond the file size, causing an “unexpected end of file” error."