### PR TITLE
validation improvements, fixes #301

### DIFF
--- a/symphonia-format-isomp4/src/atoms/avcc.rs
+++ b/symphonia-format-isomp4/src/atoms/avcc.rs
@@ -14,9 +14,7 @@ use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::stsd::VisualSampleEntry;
-use crate::atoms::{Atom, AtomHeader};
-
-const MAX_ATOM_SIZE: u64 = 1024;
+use crate::atoms::{Atom, AtomHeader, MAX_ATOM_SIZE};
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/symphonia-format-isomp4/src/atoms/co64.rs
+++ b/symphonia-format-isomp4/src/atoms/co64.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -21,7 +21,17 @@ impl Atom for Co64Atom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
 
+        // minimum data size is 4 bytes
+        let len = match header.data_len() {
+            Some(len) if len >= 4 => len as u32,
+            Some(_) => return decode_error("isomp4 (co64): atom size is less than 16 bytes"),
+            None => return decode_error("isomp4 (co64): expected atom size to be known"),
+        };
+
         let entry_count = reader.read_be_u32()?;
+        if entry_count != (len - 4) / 8 {
+            return decode_error("isomp4 (co64): invalid entry count");
+        }
 
         // TODO: Apply a limit.
         let mut chunk_offsets = Vec::with_capacity(entry_count as usize);

--- a/symphonia-format-isomp4/src/atoms/dac3.rs
+++ b/symphonia-format-isomp4/src/atoms/dac3.rs
@@ -6,11 +6,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::codecs::audio::well_known::CODEC_ID_AC3;
-use symphonia_core::errors::{Error, Result};
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::stsd::AudioSampleEntry;
-use crate::atoms::{Atom, AtomHeader};
+use crate::atoms::{Atom, AtomHeader, MAX_ATOM_SIZE};
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -21,12 +21,13 @@ pub struct Dac3Atom {
 
 impl Atom for Dac3Atom {
     fn read<B: ReadBytes>(reader: &mut B, header: AtomHeader) -> Result<Self> {
-        // AC3SpecificBox should have length
-        let len = header
-            .data_len()
-            .ok_or(Error::DecodeError("isomp4 (dac3): expected atom size to be known"))?;
+        let len = match header.data_len() {
+            Some(len) if len <= MAX_ATOM_SIZE => len as usize,
+            Some(_) => return decode_error("isomp4 (dac3): atom size is greater than 1kb"),
+            None => return decode_error("isomp4 (dac3): expected atom size to be known"),
+        };
 
-        let extra_data = reader.read_boxed_slice_exact(len as usize)?;
+        let extra_data = reader.read_boxed_slice_exact(len)?;
 
         Ok(Dac3Atom { extra_data })
     }

--- a/symphonia-format-isomp4/src/atoms/dovi.rs
+++ b/symphonia-format-isomp4/src/atoms/dovi.rs
@@ -13,8 +13,6 @@ use symphonia_core::io::ReadBytes;
 use crate::atoms::stsd::VisualSampleEntry;
 use crate::atoms::{Atom, AtomHeader};
 
-const DOVI_CONFIG_SIZE: u64 = 24;
-
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct DoviAtom {
@@ -28,7 +26,7 @@ impl Atom for DoviAtom {
         // https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby_vision_bitstreams_within_the_iso_base_media_file_format_dec2017.pdf
         // It should be 24 bytes
         let len = match header.data_len() {
-            Some(len @ DOVI_CONFIG_SIZE) => len as usize,
+            Some(len @ 24) => len as usize,
             Some(_) => return decode_error("isomp4 (dvcC/dvvC): atom size is not 24 bytes"),
             None => return decode_error("isomp4 (dvcC/dvvC): expected atom size to be known"),
         };

--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -243,6 +243,8 @@ pub struct ESDescriptor {
 
 impl ObjectDescriptor for ESDescriptor {
     fn read<B: ReadBytes>(reader: &mut B, len: u32) -> Result<Self> {
+        let pos = reader.pos();
+
         let es_id = reader.read_be_u16()?;
         let es_flags = reader.read_u8()?;
 
@@ -264,6 +266,11 @@ impl ObjectDescriptor for ESDescriptor {
 
         let mut dec_config = None;
         let mut sl_config = None;
+
+        // len should be bigger than what have been read
+        if reader.pos() - pos > len as u64 {
+            return decode_error("isomp4: es descriptor len is wrong");
+        }
 
         let mut scoped = ScopedStream::new(reader, u64::from(len) - 3);
 

--- a/symphonia-format-isomp4/src/atoms/ftyp.rs
+++ b/symphonia-format-isomp4/src/atoms/ftyp.rs
@@ -29,7 +29,7 @@ impl Atom for FtypAtom {
             .ok_or(Error::DecodeError("isomp4 (ftyp): expected atom size to be known"))?;
 
         if data_len < 8 || data_len & 0x3 != 0 {
-            return decode_error("isomp4: invalid ftyp data length");
+            return decode_error("isomp4 (ftype): invalid data length");
         }
 
         // Major

--- a/symphonia-format-isomp4/src/atoms/ftyp.rs
+++ b/symphonia-format-isomp4/src/atoms/ftyp.rs
@@ -33,7 +33,12 @@ impl Atom for FtypAtom {
         }
 
         // Major
-        let major = FourCc::new(reader.read_quad_bytes()?);
+        let Some(major) = FourCc::try_new(reader.read_quad_bytes()?)
+        else {
+            return decode_error(
+                "isomp4 (ftype): major - only ASCII characters are allowed in a FourCc",
+            );
+        };
 
         // Minor
         let minor = reader.read_quad_bytes()?;
@@ -44,8 +49,13 @@ impl Atom for FtypAtom {
         let mut compatible = Vec::new();
 
         for _ in 0..n_brands {
-            let brand = reader.read_quad_bytes()?;
-            compatible.push(FourCc::new(brand));
+            let Some(brand) = FourCc::try_new(reader.read_quad_bytes()?)
+            else {
+                return decode_error(
+                    "isomp4 (ftype): brand - only ASCII characters are allowed in a FourCc",
+                );
+            };
+            compatible.push(brand);
         }
 
         Ok(FtypAtom { major, minor, compatible })

--- a/symphonia-format-isomp4/src/atoms/hdlr.rs
+++ b/symphonia-format-isomp4/src/atoms/hdlr.rs
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::common::FourCc;
 use symphonia_core::errors::{Error, Result};
 use symphonia_core::io::ReadBytes;
 
@@ -54,7 +53,7 @@ impl Atom for HdlrAtom {
             b"subt" => HandlerType::Subtitle,
             b"text" => HandlerType::Text,
             &hdlr => {
-                warn!("unknown handler type {:?}", FourCc::new(hdlr));
+                warn!("unknown handler type {:?}", hdlr);
                 HandlerType::Other(hdlr)
             }
         };

--- a/symphonia-format-isomp4/src/atoms/hvcc.rs
+++ b/symphonia-format-isomp4/src/atoms/hvcc.rs
@@ -14,9 +14,7 @@ use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::stsd::VisualSampleEntry;
-use crate::atoms::{Atom, AtomHeader};
-
-const MAX_ATOM_SIZE: u64 = 1024;
+use crate::atoms::{Atom, AtomHeader, MAX_ATOM_SIZE};
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/symphonia-format-isomp4/src/atoms/mdhd.rs
+++ b/symphonia-format-isomp4/src/atoms/mdhd.rs
@@ -46,6 +46,11 @@ impl Atom for MdhdAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (version, _) = header.read_extended_header(reader)?;
 
+        let expected_len = if version == 0 { 20 } else { 32 };
+        if header.data_len() != Some(expected_len) {
+            return decode_error("isomp4 (mdhd): atom size is not 32 or 44 bytes");
+        }
+
         let mut mdhd =
             MdhdAtom { ctime: 0, mtime: 0, timescale: 0, duration: 0, language: String::new() };
 
@@ -67,7 +72,7 @@ impl Atom for MdhdAtom {
                 mdhd.duration = reader.read_be_u64()?;
             }
             _ => {
-                return decode_error("isomp4: invalid mdhd version");
+                return decode_error("isomp4 (mdhd): invalid version");
             }
         }
 

--- a/symphonia-format-isomp4/src/atoms/mdia.rs
+++ b/symphonia-format-isomp4/src/atoms/mdia.rs
@@ -42,15 +42,15 @@ impl Atom for MdiaAtom {
         }
 
         if mdhd.is_none() {
-            return decode_error("isomp4: missing mdhd atom");
+            return decode_error("isomp4 (mdia): missing mdhd atom");
         }
 
         if hdlr.is_none() {
-            return decode_error("isomp4: missing hdlr atom");
+            return decode_error("isomp4 (mdia): missing hdlr atom");
         }
 
         if minf.is_none() {
-            return decode_error("isomp4: missing minf atom");
+            return decode_error("isomp4 (mdia): missing minf atom");
         }
 
         Ok(MdiaAtom { mdhd: mdhd.unwrap(), hdlr: hdlr.unwrap(), minf: minf.unwrap() })

--- a/symphonia-format-isomp4/src/atoms/mehd.rs
+++ b/symphonia-format-isomp4/src/atoms/mehd.rs
@@ -22,11 +22,16 @@ impl Atom for MehdAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (version, _) = header.read_extended_header(reader)?;
 
+        let expected_len = if version == 0 { 4 } else { 8 };
+        if header.data_len() != Some(expected_len) {
+            return decode_error("isomp4 (mehd): atom size is not 16 or 20 bytes");
+        }
+
         let fragment_duration = match version {
             0 => u64::from(reader.read_be_u32()?),
             1 => reader.read_be_u64()?,
             _ => {
-                return decode_error("isomp4: invalid mehd version");
+                return decode_error("isomp4 (mehd): invalid version");
             }
         };
 

--- a/symphonia-format-isomp4/src/atoms/mfhd.rs
+++ b/symphonia-format-isomp4/src/atoms/mfhd.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -21,6 +21,10 @@ pub struct MfhdAtom {
 impl Atom for MfhdAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
+
+        if header.data_len() != Some(4) {
+            return decode_error("isomp4 (mfhd): atom size is not 16 bytes");
+        }
 
         let sequence_number = reader.read_be_u32()?;
 

--- a/symphonia-format-isomp4/src/atoms/minf.rs
+++ b/symphonia-format-isomp4/src/atoms/minf.rs
@@ -40,7 +40,7 @@ impl Atom for MinfAtom {
         }
 
         if stbl.is_none() {
-            return decode_error("isomp4: missing stbl atom");
+            return decode_error("isomp4 (minf): missing stbl atom");
         }
 
         Ok(MinfAtom { smhd, stbl: stbl.unwrap() })

--- a/symphonia-format-isomp4/src/atoms/mod.rs
+++ b/symphonia-format-isomp4/src/atoms/mod.rs
@@ -100,6 +100,8 @@ pub use trun::TrunAtom;
 pub use udta::UdtaAtom;
 pub use wave::WaveAtom;
 
+pub(crate) const MAX_ATOM_SIZE: u64 = 1024;
+
 /// Atom types.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AtomType {

--- a/symphonia-format-isomp4/src/atoms/moof.rs
+++ b/symphonia-format-isomp4/src/atoms/moof.rs
@@ -44,7 +44,7 @@ impl Atom for MoofAtom {
         }
 
         if mfhd.is_none() {
-            return decode_error("isomp4: missing mfhd atom");
+            return decode_error("isomp4 (moof): missing mfhd atom");
         }
 
         // The position of the first byte of the entire moof atom.

--- a/symphonia-format-isomp4/src/atoms/moov.rs
+++ b/symphonia-format-isomp4/src/atoms/moov.rs
@@ -70,7 +70,7 @@ impl Atom for MoovAtom {
         }
 
         if mvhd.is_none() {
-            return decode_error("isomp4: missing mvhd atom");
+            return decode_error("isomp4 (moov): missing mvhd atom");
         }
 
         // If fragmented, the mvex atom should contain a trex atom for each trak atom in moov.
@@ -80,7 +80,7 @@ impl Atom for MoovAtom {
                 let found = mvex.trexs.iter().any(|trex| trex.track_id == trak.tkhd.id);
 
                 if !found {
-                    warn!("missing trex atom for trak with id={}", trak.tkhd.id);
+                    warn!("isomp4 (moov): missing trex atom for trak with id={}", trak.tkhd.id);
                 }
             }
         }

--- a/symphonia-format-isomp4/src/atoms/mvhd.rs
+++ b/symphonia-format-isomp4/src/atoms/mvhd.rs
@@ -34,6 +34,11 @@ impl Atom for MvhdAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (version, _) = header.read_extended_header(reader)?;
 
+        let expected_len = if version == 0 { 96 } else { 108 };
+        if header.data_len() != Some(expected_len) {
+            return decode_error("isomp4 (mvhd): atom size is not 108 or 120 bytes");
+        }
+
         let mut mvhd =
             MvhdAtom { ctime: 0, mtime: 0, timescale: 0, duration: 0, volume: Default::default() };
 
@@ -55,7 +60,7 @@ impl Atom for MvhdAtom {
                 mvhd.timescale = reader.read_be_u32()?;
                 mvhd.duration = reader.read_be_u64()?;
             }
-            _ => return decode_error("isomp4: invalid mvhd version"),
+            _ => return decode_error("isomp4 (mvhd): invalid version"),
         }
 
         // Ignore the preferred playback rate.

--- a/symphonia-format-isomp4/src/atoms/smhd.rs
+++ b/symphonia-format-isomp4/src/atoms/smhd.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -22,6 +22,10 @@ pub struct SmhdAtom {
 impl Atom for SmhdAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
+
+        if header.data_len() != Some(4) {
+            return decode_error("isomp4 (smhd): atom size is not 16 bytes");
+        }
 
         // Stereo balance
         let balance = FpI8::parse_raw(reader.read_be_u16()? as i16);

--- a/symphonia-format-isomp4/src/atoms/stbl.rs
+++ b/symphonia-format-isomp4/src/atoms/stbl.rs
@@ -89,10 +89,13 @@ impl Atom for StblAtom {
             warn!("isomp4 (stbl): missing stco or co64 atom");
         }
 
+        let mut stsc = stsc.unwrap();
+        stsc.post_processing(&stco, &co64)?;
+
         Ok(StblAtom {
             stsd: stsd.unwrap(),
             stts: stts.unwrap(),
-            stsc: stsc.unwrap(),
+            stsc,
             stsz: stsz.unwrap(),
             stco,
             co64,

--- a/symphonia-format-isomp4/src/atoms/stbl.rs
+++ b/symphonia-format-isomp4/src/atoms/stbl.rs
@@ -69,24 +69,24 @@ impl Atom for StblAtom {
         }
 
         if stsd.is_none() {
-            return decode_error("isomp4: missing stsd atom");
+            return decode_error("isomp4 (stbl): missing stsd atom");
         }
 
         if stts.is_none() {
-            return decode_error("isomp4: missing stts atom");
+            return decode_error("isomp4 (stbl): missing stts atom");
         }
 
         if stsc.is_none() {
-            return decode_error("isomp4: missing stsc atom");
+            return decode_error("isomp4 (stbl): missing stsc atom");
         }
 
         if stsz.is_none() {
-            return decode_error("isomp4: missing stsz atom");
+            return decode_error("isomp4 (stbl): missing stsz atom");
         }
 
         if stco.is_none() && co64.is_none() {
             // This is a spec. violation, but some m4a files appear to lack these atoms.
-            warn!("missing stco or co64 atom");
+            warn!("isomp4 (stbl): missing stco or co64 atom");
         }
 
         Ok(StblAtom {

--- a/symphonia-format-isomp4/src/atoms/stco.rs
+++ b/symphonia-format-isomp4/src/atoms/stco.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -21,7 +21,17 @@ impl Atom for StcoAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
 
+        // minimum data size is 4 bytes
+        let len = match header.data_len() {
+            Some(len) if len >= 4 => len as u32,
+            Some(_) => return decode_error("isomp4 (stco): atom size is less than 16 bytes"),
+            None => return decode_error("isomp4 (stco): expected atom size to be known"),
+        };
+
         let entry_count = reader.read_be_u32()?;
+        if entry_count != (len - 4) / 4 {
+            return decode_error("isomp4 (stco): invalid entry count");
+        }
 
         // TODO: Apply a limit.
         let mut chunk_offsets = Vec::with_capacity(entry_count as usize);

--- a/symphonia-format-isomp4/src/atoms/stsc.rs
+++ b/symphonia-format-isomp4/src/atoms/stsc.rs
@@ -8,7 +8,7 @@
 use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
-use crate::atoms::{Atom, AtomHeader};
+use crate::atoms::{Atom, AtomHeader, Co64Atom, StcoAtom};
 
 #[derive(Debug)]
 pub struct StscEntry {
@@ -53,6 +53,50 @@ impl StscAtom {
         // get with an index of 0, and safely returning None.
         self.entries.get(left - 1)
     }
+
+    pub fn post_processing(
+        &mut self,
+        stco: &Option<StcoAtom>,
+        co64: &Option<Co64Atom>,
+    ) -> Result<()> {
+        // Post-process entries to check for errors and calculate the file sample.
+        if !self.entries.is_empty() {
+            // stco and co64 can both be absent, this is a spec. violation, but some m4a files appear to lack these atoms.
+            // set maximum possible total_chunks in this case
+            let mut total_chunks = u32::MAX;
+
+            if let Some(stco) = stco {
+                total_chunks = stco.chunk_offsets.len() as u32;
+            }
+            else if let Some(co64) = co64 {
+                total_chunks = co64.chunk_offsets.len() as u32;
+            }
+
+            for i in 0..self.entries.len() - 1 {
+                // Validate that first_chunk is within the total number of chunks
+                // first_chunk index was transformed to be starting from 0
+                if self.entries[i].first_chunk >= total_chunks
+                    || self.entries[i + 1].first_chunk >= total_chunks
+                {
+                    return decode_error(
+                        "isomp4 (stsc): entry's first chunk is bigger than total chunk number",
+                    );
+                }
+
+                // Validate that first_chunk is monotonic across all entries.
+                if self.entries[i + 1].first_chunk <= self.entries[i].first_chunk {
+                    return decode_error("isomp4 (stsc): entry's first chunk not monotonic");
+                }
+
+                let n = self.entries[i + 1].first_chunk - self.entries[i].first_chunk;
+
+                self.entries[i + 1].first_sample =
+                    self.entries[i].first_sample + (n * self.entries[i].samples_per_chunk);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Atom for StscAtom {
@@ -75,37 +119,26 @@ impl Atom for StscAtom {
         let mut entries = Vec::with_capacity(entry_count as usize);
 
         for _ in 0..entry_count {
-            entries.push(StscEntry {
-                first_chunk: reader.read_be_u32()? - 1,
-                first_sample: 0,
-                samples_per_chunk: reader.read_be_u32()?,
-                sample_desc_index: reader.read_be_u32()?,
-            });
-        }
+            let first_chunk = reader.read_be_u32()?;
 
-        // Post-process entries to check for errors and calculate the file sample.
-        if entry_count > 0 {
-            for i in 0..entry_count as usize - 1 {
-                // Validate that first_chunk is monotonic across all entries.
-                if entries[i + 1].first_chunk < entries[i].first_chunk {
-                    return decode_error("isomp4 (stsc): entry's first chunk not monotonic");
-                }
-
-                // Validate that samples per chunk is > 0. Could the entry be ignored?
-                if entries[i].samples_per_chunk == 0 {
-                    return decode_error("isomp4 (stsc): entry has 0 samples per chunk");
-                }
-
-                let n = entries[i + 1].first_chunk - entries[i].first_chunk;
-
-                entries[i + 1].first_sample =
-                    entries[i].first_sample + (n * entries[i].samples_per_chunk);
+            // Validate that first chunk is indexed from 1
+            if first_chunk == 0 {
+                return decode_error("isomp4 (stsc):  entry's first chunk undex should be from 1");
             }
+
+            let samples_per_chunk = reader.read_be_u32()?;
 
             // Validate that samples per chunk is > 0. Could the entry be ignored?
-            if entries[entry_count as usize - 1].samples_per_chunk == 0 {
+            if samples_per_chunk == 0 {
                 return decode_error("isomp4 (stsc): entry has 0 samples per chunk");
             }
+
+            entries.push(StscEntry {
+                first_chunk: first_chunk - 1,
+                first_sample: 0,
+                samples_per_chunk,
+                sample_desc_index: reader.read_be_u32()?,
+            });
         }
 
         Ok(StscAtom { entries })

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -50,11 +50,11 @@ impl Atom for StsdAtom {
         let num_entries = reader.read_be_u32()?;
 
         if num_entries == 0 {
-            return decode_error("isomp4: missing sample entry");
+            return decode_error("isomp4 (stsd): missing sample entry");
         }
 
         if num_entries > 1 {
-            return unsupported_error("isomp4: more than 1 sample entry");
+            return unsupported_error("isomp4 (stsd): more than 1 sample entry");
         }
 
         let sample_entry_header = AtomHeader::read(reader)?;

--- a/symphonia-format-isomp4/src/atoms/stsz.rs
+++ b/symphonia-format-isomp4/src/atoms/stsz.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -30,10 +30,21 @@ impl Atom for StszAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
 
+        // minimum data size is 8 bytes
+        let len = match header.data_len() {
+            Some(len) if len >= 8 => len as u32,
+            Some(_) => return decode_error("isomp4 (stsz): atom size is less than 16 bytes"),
+            None => return decode_error("isomp4 (stsz): expected atom size to be known"),
+        };
+
         let sample_size = reader.read_be_u32()?;
         let sample_count = reader.read_be_u32()?;
 
         let sample_sizes = if sample_size == 0 {
+            if sample_count != (len - 8) / 4 {
+                return decode_error("isomp4 (stsz): invalid sample count");
+            }
+
             // TODO: Apply a limit.
             let mut entries = Vec::with_capacity(sample_count as usize);
 

--- a/symphonia-format-isomp4/src/atoms/traf.rs
+++ b/symphonia-format-isomp4/src/atoms/traf.rs
@@ -50,7 +50,7 @@ impl Atom for TrafAtom {
 
         // Tfhd is mandatory.
         if tfhd.is_none() {
-            return decode_error("isomp4: missing tfhd atom");
+            return decode_error("isomp4 (traf): missing tfhd atom");
         }
 
         Ok(TrafAtom { tfhd: tfhd.unwrap(), truns, total_sample_count })

--- a/symphonia-format-isomp4/src/atoms/trak.rs
+++ b/symphonia-format-isomp4/src/atoms/trak.rs
@@ -49,12 +49,12 @@ impl Atom for TrakAtom {
 
         let Some(tkhd_atom) = tkhd
         else {
-            return decode_error("isomp4: missing tkhd atom");
+            return decode_error("isomp4 (trak): missing tkhd atom");
         };
 
         let Some(mdia_atom) = mdia
         else {
-            return decode_error("isomp4: missing mdia atom");
+            return decode_error("isomp4 (trak): missing mdia atom");
         };
 
         let duration =

--- a/symphonia-format-isomp4/src/atoms/trex.rs
+++ b/symphonia-format-isomp4/src/atoms/trex.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::errors::Result;
+use symphonia_core::errors::{decode_error, Result};
 use symphonia_core::io::ReadBytes;
 
 use crate::atoms::{Atom, AtomHeader};
@@ -29,6 +29,10 @@ pub struct TrexAtom {
 impl Atom for TrexAtom {
     fn read<B: ReadBytes>(reader: &mut B, mut header: AtomHeader) -> Result<Self> {
         let (_, _) = header.read_extended_header(reader)?;
+
+        if header.data_len() != Some(20) {
+            return decode_error("isomp4 (trex): atom size is not 32 bytes");
+        }
 
         Ok(TrexAtom {
             track_id: reader.read_be_u32()?,

--- a/symphonia/fuzz/Cargo.toml
+++ b/symphonia/fuzz/Cargo.toml
@@ -34,3 +34,9 @@ name = "decode_mp3"
 path = "fuzz_targets/decode_mp3.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "decode_aac"
+path = "fuzz_targets/decode_aac.rs"
+test = false
+doc = false

--- a/symphonia/fuzz/fuzz_targets/decode_aac.rs
+++ b/symphonia/fuzz/fuzz_targets/decode_aac.rs
@@ -1,15 +1,15 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use symphonia::core::codecs::audio::{AudioCodecParameters, AudioDecoder};
-use symphonia::core::codecs::audio::well_known::CODEC_ID_MP3;
+use symphonia::core::codecs::audio::well_known::CODEC_ID_AAC;
 use symphonia::core::formats::Packet;
-use symphonia::default::codecs::MpaDecoder;
+use symphonia::default::codecs::AacDecoder;
 
 fuzz_target!(|data: Vec<u8>| {
     let mut codec_params = AudioCodecParameters::new();
-    codec_params.for_codec(CODEC_ID_MP3);
+    codec_params.for_codec(CODEC_ID_AAC);
 
-    if let Ok(mut decoder) = MpaDecoder::try_new(&codec_params, &Default::default()) {
+    if let Ok(mut decoder) = AacDecoder::try_new(&codec_params, &Default::default()) {
         let packet = Packet::new_from_boxed_slice(0, 0, 0, data.into_boxed_slice());
         decoder.decode(&packet).ok();
     }

--- a/symphonia/fuzz/fuzz_targets/decode_any.rs
+++ b/symphonia/fuzz/fuzz_targets/decode_any.rs
@@ -1,39 +1,32 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::probe::Hint;
+use symphonia::core::formats::TrackType;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
 
 fuzz_target!(|data: Vec<u8>| {
     let data = std::io::Cursor::new(data);
-
     let source = symphonia::core::io::MediaSourceStream::new(Box::new(data), Default::default());
-
-    match symphonia::default::get_probe().format(
+    
+    if let Ok(mut format) = symphonia::default::get_probe().probe(
         &Hint::new(),
         source,
-        &FormatOptions::default(),
-        &MetadataOptions::default(),
+        FormatOptions::default(),
+        MetadataOptions::default(),
     ) {
-        Ok(mut probed) => {
-            let track = probed.format.default_track().unwrap();
-
-            let mut decoder = match symphonia::default::get_codecs()
-                .make(&track.codec_params, &DecoderOptions::default())
-            {
-                Ok(d) => d,
-                Err(_) => return,
-            };
-
-            loop {
-                let packet = match probed.format.next_packet() {
-                    Ok(p) => p,
-                    Err(_) => return,
-                };
-                let _ = decoder.decode(&packet);
+        if let Some(track) = format.default_track(TrackType::Audio) {
+            if let Some(codec_params) = track.codec_params.as_ref() {
+                if let Ok(mut decoder) = symphonia::default::get_codecs().make_audio_decoder(
+                    &codec_params.audio().unwrap(),
+                    &AudioDecoderOptions::default(),
+                ) {
+                    while let Ok(Some(packet)) = format.next_packet() {
+                        let _ = decoder.decode(&packet);
+                    }
+                }
             }
         }
-        Err(_) => {}
     }
 });


### PR DESCRIPTION
Added More Validations for isomp4 to prevent some panics, Fixes #301, #300

1. **Atom Size Validations:** Implemented strict, minimum, and maximum size validations for numerous atoms where feasible.
2. **Entry Count Limits:** Did not impose limits on entry counts; TODOs related to this are still pending.
3. **Refactored stsc Atom:**
- Initial Validations: Performed during atom creation.
- Post-Processing Validations: Conducted after other atoms are available, including more complex checks such as comparing entry.first_chunk with the total number of chunks.
4. **Refactored esds Atom:** Modified to allow unidentified descriptor without causing panics.

Note: This update does not resolve all potential panic scenarios or address issues related to high memory consumption.
**Requires** a full regression run on as many files as possible to revalidate the constants put for validations.