### PR TITLE
riff: fix clippy warnings, fix overflow with u16 for frames_per_block calculation

### DIFF
--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -145,12 +145,7 @@ impl ParseChunk for CommonChunk {
         let sample_size = reader.read_be_i16()?;
         let sample_rate = read_sample_rate(reader)?;
 
-        let format_data = Self::read_pcm_fmt(sample_size as u16, n_channels as u16);
-
-        let format_data = match format_data {
-            Ok(data) => data,
-            Err(e) => return Err(e),
-        };
+        let format_data = Self::read_pcm_fmt(sample_size as u16, n_channels as u16)?;
 
         Ok(CommonChunk { n_channels, n_sample_frames, sample_size, sample_rate, format_data })
     }
@@ -232,12 +227,7 @@ impl CommonChunkParser for ChunkParser<CommonChunk> {
             b"sowt" | b"SOWT" => CommonChunk::read_sowt_fmt(sample_size as u16, n_channels as u16),
             b"twos" | b"TWOS" => CommonChunk::read_twos_fmt(sample_size as u16, n_channels as u16),
             _ => return unsupported_error("aifc: Compression type not implemented"),
-        };
-
-        let format_data = match format_data {
-            Ok(data) => data,
-            Err(e) => return Err(e),
-        };
+        }?;
 
         Ok(CommonChunk { n_channels, n_sample_frames, sample_size, sample_rate, format_data })
     }

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -368,17 +368,17 @@ impl WaveFormatChunk {
             //| WaveFormatData::Extensible(WaveFormatExtensible { codec, bits_per_sample, .. })
                 if codec == CODEC_ID_ADPCM_MS =>
             {
-                let frames_per_block = ((((self.block_align - (7 * self.n_channels)) * 8)
-                    / (bits_per_sample * self.n_channels))
-                    + 2) as u64;
+                let frames_per_block = ((self.block_align - (7 * self.n_channels)) as u64 * 8)
+                    / (bits_per_sample * self.n_channels) as u64
+                    + 2;
                 PacketInfo::with_blocks(self.block_align, frames_per_block)
             }
             FormatData::Adpcm(FormatAdpcm { codec, bits_per_sample, .. })
                 if codec == CODEC_ID_ADPCM_IMA_WAV =>
             {
-                let frames_per_block = (((self.block_align - (4 * self.n_channels)) * 8)
-                    / (bits_per_sample * self.n_channels)
-                    + 1) as u64;
+                let frames_per_block = ((self.block_align - (4 * self.n_channels)) as u64 * 8)
+                    / (bits_per_sample * self.n_channels) as u64
+                    + 1;
                 PacketInfo::with_blocks(self.block_align, frames_per_block)
             }
             _ => Ok(PacketInfo::without_blocks(self.block_align)),


### PR DESCRIPTION
should fix builds for other PRs.