### PR TITLE
aac: refactor approximate frame count, fuzzy fixes

### DIFF
--- a/symphonia-codec-aac/src/aac/cpe.rs
+++ b/symphonia-codec-aac/src/aac/cpe.rs
@@ -59,7 +59,8 @@ impl ChannelPair {
 
         if common_window {
             // Decode the common ICS info block into the first channel.
-            self.ics0.info.decode(bs)?;
+            // do not call self.ics0.info.decode() as it will skip required validations present in self.ics0.decode_info()
+            self.ics0.decode_info(bs)?;
 
             // Mid-side stereo mask decoding.
             self.ms_mask_present = bs.read_bits_leq32(2)? as u8;

--- a/symphonia-codec-aac/src/aac/ics/mod.rs
+++ b/symphonia-codec-aac/src/aac/ics/mod.rs
@@ -106,6 +106,7 @@ impl IcsInfo {
         }
     }
 
+    /// this method should be called from Ics::decode_info() which will perform additional validations for max_sfb
     pub fn decode<B: ReadBitsLtr>(&mut self, bs: &mut B) -> Result<()> {
         self.prev_window_sequence = self.window_sequence;
         self.prev_window_shape = self.window_shape;
@@ -291,6 +292,16 @@ impl Ics {
         self.sfb_cb[g][sfb] == INTENSITY_HCB
     }
 
+    pub fn decode_info<B: ReadBitsLtr>(&mut self, bs: &mut B) -> Result<()> {
+        self.info.decode(bs)?;
+
+        // validate info.max_sfb - it should not be bigger than bands array len - 1
+        if self.info.max_sfb + 1 > self.get_bands().len() {
+            return decode_error("aac: ics info max_sfb is too big for the bands size");
+        }
+        Ok(())
+    }
+
     fn decode_scale_factor_data<B: ReadBitsLtr>(&mut self, bs: &mut B) -> Result<()> {
         let mut noise_pcm_flag = true;
         let mut scf_intensity = -INTENSITY_SCALE_MIN;
@@ -407,7 +418,8 @@ impl Ics {
 
         // If a common window is used, a common ICS info was decoded previously.
         if !common_window {
-            self.info.decode(bs)?;
+            // do not call self.info.decode() as it will skip required validations present in the decode_info()
+            self.decode_info(bs)?;
         }
 
         self.decode_section_data(bs)?;


### PR DESCRIPTION
refactored aac aproximate_frame_count() method. It had some issues which causes panic. Should fix cases from https://github.com/qarmin/Automated-Fuzzer/actions/runs/12516290494 (REPORTS___SYMPHONIA*)

1. renamed total_len to remaining_len because this is not the length of the whole file, but it was considered such in some places.
2. first sample point to start from the beginning, file can contain a single frame
3. check step to be bigger than 0 to avoid panic
4. skip the rest of the frame after the header is read to avoid looking for sync word in the audio data
5. break if reading 100 frames overlap next sample point

I haven't tested on VBR aac to observe any improvements, It was https://github.com/pdeljanov/Symphonia/issues/196#issuecomment-1960507107that approximate method is not perfect there