### PR TITLE
core: advance reader's position if pattern cannot be found, fixes out of memory from #301

### DIFF
--- a/symphonia-core/src/io/buf_reader.rs
+++ b/symphonia-core/src/io/buf_reader.rs
@@ -57,21 +57,22 @@ impl<'a> BufReader<'a> {
         // return the remainder of the buffer or scan_length bytes, which ever is shorter, we return
         // that here.
         if remaining < pattern.len() || scan_len < pattern.len() {
+            self.pos = end;
             return Ok(&self.buf[start..end]);
         }
 
-        let mut j = start;
-        let mut i = start + pattern.len();
+        let mut i = start;
+        let mut j = start + pattern.len();
 
-        while i < end {
-            if &self.buf[j..i] == pattern {
+        while j < end {
+            if &self.buf[i..j] == pattern {
                 break;
             }
-            i += align;
             j += align;
+            i += align;
         }
 
-        self.pos = cmp::min(i, self.buf.len());
+        self.pos = cmp::min(j, self.buf.len());
         Ok(&self.buf[start..self.pos])
     }
 


### PR DESCRIPTION
This addresses out-of-memory errors mentioned in the following comment: https://github.com/pdeljanov/Symphonia/issues/301#issuecomment-2569727809.

Issue description:

For a big buffer where the pattern was not found at the end, the reader advanced its position to the end of the buffer.
For a buffer smaller than the pattern length, the reader did not advance its position and entered into infinite loop while reading tags.

This commit ensures that the reader's position is always advanced, resolving the issue.