### PR TITLE
fix(isomp4): Update MIME type for m4a files to audio/mp4

### DIFF
--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -311,7 +311,7 @@ impl QueryDescriptor for IsoMp4Reader {
             "isomp4",
             "ISO Base Media File Format",
             &["mp4", "m4a", "m4p", "m4b", "m4r", "m4v", "mov"],
-            &["video/mp4", "audio/m4a"],
+            &["video/mp4", "audio/mp4"],
             &[b"ftyp"] // Top-level atoms
         )]
     }


### PR DESCRIPTION
Changed the MIME type from "audio/m4a" to "audio/mp4" in the format descriptor, as audio/mp4 is the standard MIME type for MPEG-4 audio files according to IANA specifications.