### PR TITLE
no_std for symphonia-core: switch to core and alloc

### DIFF
--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -8,11 +8,13 @@
 //! The `audio` module provides primitives for working with multi-channel audio buffers of varying
 //! sample formats.
 
-use std::borrow::Cow;
-use std::fmt;
-use std::marker::PhantomData;
-use std::mem;
-use std::vec::Vec;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem;
 
 use arrayvec::ArrayVec;
 use bitflags::bitflags;

--- a/symphonia-core/src/checksum/md5.rs
+++ b/symphonia-core/src/checksum/md5.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::cmp;
+use core::cmp;
 
 use crate::io::Monitor;
 

--- a/symphonia-core/src/codecs.rs
+++ b/symphonia-core/src/codecs.rs
@@ -8,9 +8,10 @@
 //! The `codec` module provides the traits and support structures necessary to implement audio codec
 //! decoders.
 
+use alloc::boxed::Box;
+use core::default::Default;
+use core::fmt;
 use std::collections::HashMap;
-use std::default::Default;
-use std::fmt;
 
 use crate::audio::{AudioBufferRef, Channels, Layout};
 use crate::errors::{unsupported_error, Result};

--- a/symphonia-core/src/conv.rs
+++ b/symphonia-core/src/conv.rs
@@ -28,7 +28,7 @@ pub mod dither {
     use super::FromSample;
     use crate::sample::Sample;
     use crate::sample::{i24, u24};
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     mod prng {
         #[inline]
@@ -679,7 +679,7 @@ impl<S> ConvertibleSample for S where
 mod tests {
     use super::FromSample;
     use crate::sample::{i24, u24, Sample};
-    use std::{i16, i32, i8, u16, u32, u8};
+    use core::{i16, i32, i8, u16, u32, u8};
 
     #[test]
     fn verify_u8_from_sample() {

--- a/symphonia-core/src/dsp/fft.rs
+++ b/symphonia-core/src/dsp/fft.rs
@@ -10,8 +10,8 @@
 //! The complex (I)FFT in this module supports a size up-to 65536. The FFT is implemented using the
 //! radix-2 Cooley-Tukey algorithm.
 
-use std::convert::TryInto;
-use std::f32;
+use core::convert::TryInto;
+use core::f32;
 
 use lazy_static::lazy_static;
 
@@ -25,7 +25,7 @@ macro_rules! fft_twiddle_table {
 
                 let mut table = [Default::default(); N >> 1];
 
-                let theta = std::f64::consts::PI / (N >> 1) as f64;
+                let theta = core::f64::consts::PI / (N >> 1) as f64;
 
                 for (k, t) in table.iter_mut().enumerate() {
                     let angle = theta * k as f64;
@@ -71,7 +71,7 @@ fn fft_twiddle_factors(n: usize) -> &'static [Complex] {
 
 /// The complex Fast Fourier Transform (FFT).
 pub struct Fft {
-    perm: Box<[u16]>,
+    perm: alloc::boxed::Box<[u16]>,
 }
 
 impl Fft {
@@ -409,7 +409,8 @@ fn fft2(x: &mut [Complex; 2]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::f64;
+    use alloc::vec::Vec;
+    use core::f64;
 
     /// Compute a naive DFT.
     fn dft_naive(x: &[Complex], y: &mut [Complex]) {

--- a/symphonia-core/src/dsp/mdct/mod.rs
+++ b/symphonia-core/src/dsp/mdct/mod.rs
@@ -27,7 +27,7 @@ pub use no_simd::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::f64;
+    use core::f64;
 
     fn imdct_analytical(x: &[f32], y: &mut [f32], scale: f64) {
         assert!(y.len() == 2 * x.len());

--- a/symphonia-core/src/dsp/mdct/simd.rs
+++ b/symphonia-core/src/dsp/mdct/simd.rs
@@ -7,8 +7,10 @@
 
 //! The Modified Discrete Cosine Transform (MDCT) implemented with SIMD optimizations.
 
-use std::sync::Arc;
-
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use rustfft::num_complex::Complex;
 
 /// The Inverse Modified Discrete Transform (IMDCT).
@@ -42,7 +44,7 @@ impl Imdct {
         let mut twiddle = Vec::with_capacity(n2);
 
         let alpha = 1.0 / 8.0 + if scale.is_sign_positive() { 0.0 } else { n2 as f64 };
-        let pi_n = std::f64::consts::PI / n as f64;
+        let pi_n = core::f64::consts::PI / n as f64;
         let sqrt_scale = scale.abs().sqrt();
 
         for k in 0..n2 {

--- a/symphonia-core/src/errors.rs
+++ b/symphonia-core/src/errors.rs
@@ -7,10 +7,10 @@
 
 //! The `errors` module defines the common error type.
 
-use std::error;
-use std::fmt;
+use core::error;
+use core::fmt;
+use core::result;
 use std::io;
-use std::result;
 
 /// `SeekErrorKind` is a list of generic reasons why a seek may fail.
 #[derive(Debug)]

--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -13,6 +13,9 @@ use crate::errors::Result;
 use crate::io::{BufReader, MediaSourceStream};
 use crate::meta::{Metadata, Tag};
 use crate::units::{Time, TimeStamp};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub mod prelude {
     //! The `formats` module prelude.
@@ -328,6 +331,7 @@ pub mod util {
     //! Helper utilities for implementing `FormatReader`s.
 
     use super::Packet;
+    use alloc::vec::Vec;
 
     /// A `SeekPoint` is a mapping between a sample or frame number to byte offset within a media
     /// stream.

--- a/symphonia-core/src/io/scoped_stream.rs
+++ b/symphonia-core/src/io/scoped_stream.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::cmp;
+use core::cmp;
 use std::io;
 
 use super::{FiniteStream, ReadBytes, SeekBuffered};

--- a/symphonia-core/src/lib.rs
+++ b/symphonia-core/src/lib.rs
@@ -12,6 +12,8 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::manual_range_contains)]
 
+extern crate alloc;
+
 pub mod audio;
 pub mod checksum;
 pub mod codecs;

--- a/symphonia-core/src/meta.rs
+++ b/symphonia-core/src/meta.rs
@@ -7,11 +7,14 @@
 
 //! The `meta` module defines basic metadata elements, and management structures.
 
-use std::borrow::Cow;
-use std::collections::VecDeque;
-use std::convert::From;
-use std::fmt;
-use std::num::NonZeroU32;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::collections::VecDeque;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::convert::From;
+use core::fmt;
+use core::num::NonZeroU32;
 
 use crate::errors::Result;
 use crate::io::MediaSourceStream;

--- a/symphonia-core/src/probe.rs
+++ b/symphonia-core/src/probe.rs
@@ -12,10 +12,16 @@ use crate::errors::{unsupported_error, Result};
 use crate::formats::{FormatOptions, FormatReader};
 use crate::io::{MediaSourceStream, ReadBytes, SeekBuffered};
 use crate::meta::{Metadata, MetadataLog, MetadataOptions, MetadataReader};
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use log::{debug, error};
 
 mod bloom {
+    use alloc::boxed::Box;
+    use alloc::vec;
 
     fn fnv1a32(value: &[u8; 2]) -> u32 {
         const INIT: u32 = 0x811c_9dc5;

--- a/symphonia-core/src/sample.rs
+++ b/symphonia-core/src/sample.rs
@@ -7,7 +7,7 @@
 
 //! The `sample` module defines the core audio sample trait and any non-primitive sample data types.
 
-use std::fmt;
+use core::fmt;
 
 use crate::util::clamp::{clamp_f32, clamp_f64, clamp_i24, clamp_u24};
 

--- a/symphonia-core/src/units.rs
+++ b/symphonia-core/src/units.rs
@@ -7,7 +7,7 @@
 
 //! The `units` module provides definitions for common units.
 
-use std::fmt;
+use core::fmt;
 
 /// A `TimeStamp` represents an instantenous instant in time since the start of a stream. One
 /// `TimeStamp` "tick" is equivalent to the stream's `TimeBase` in seconds.
@@ -118,15 +118,15 @@ impl From<f64> for Time {
     }
 }
 
-impl From<std::time::Duration> for Time {
-    fn from(duration: std::time::Duration) -> Self {
+impl From<core::time::Duration> for Time {
+    fn from(duration: core::time::Duration) -> Self {
         Time::new(duration.as_secs(), f64::from(duration.subsec_nanos()) / 1_000_000_000.0)
     }
 }
 
-impl From<Time> for std::time::Duration {
+impl From<Time> for core::time::Duration {
     fn from(time: Time) -> Self {
-        std::time::Duration::new(time.seconds, (1_000_000_000.0 * time.frac) as u32)
+        core::time::Duration::new(time.seconds, (1_000_000_000.0 * time.frac) as u32)
     }
 }
 
@@ -243,7 +243,7 @@ impl fmt::Display for TimeBase {
 #[cfg(test)]
 mod tests {
     use super::{Time, TimeBase};
-    use std::time::Duration;
+    use core::time::Duration;
 
     #[test]
     fn verify_timebase() {

--- a/symphonia-core/src/util.rs
+++ b/symphonia-core/src/util.rs
@@ -331,7 +331,7 @@ pub mod clamp {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use std::{i16, i32, i64, i8, u16, u32, u64, u8};
+        use core::{i16, i32, i64, i8, u16, u32, u64, u8};
 
         #[test]
         fn verify_clamp() {


### PR DESCRIPTION
Hello again,

This is the first, least intrusive step in the direction of supporting no_std build environment. I switched all `std::` imports to their `core::` or `alloc::` counterparts leaving the rest untouched. This change should be 100% backwards compatible and make the further changes less noisy. 

I intend to follow the same path as described in https://github.com/pdeljanov/Symphonia/pull/244 but in smaller steps this time around :) 