### PR TITLE
no_std symphonia-core: replace io::Result with crate::Result

### DIFF
--- a/symphonia-codec-aac/src/aac/codebooks.rs
+++ b/symphonia-codec-aac/src/aac/codebooks.rs
@@ -6,6 +6,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::io::{vlc::*, ReadBitsLtr};
+use symphonia_core::Result;
 
 use lazy_static::lazy_static;
 
@@ -500,7 +501,7 @@ pub struct QuadsCodebook {
 
 impl QuadsCodebook {
     #[inline(always)]
-    pub fn read_quant<B: ReadBitsLtr>(&self, bs: &mut B) -> std::io::Result<(u8, u8, u8, u8)> {
+    pub fn read_quant<B: ReadBitsLtr>(&self, bs: &mut B) -> Result<(u8, u8, u8, u8)> {
         bs.read_codebook(&self.codebook).map(|(cw, _)| AAC_QUADS[cw as usize])
     }
 }
@@ -522,7 +523,7 @@ pub struct PairsCodebook {
 
 impl PairsCodebook {
     #[inline(always)]
-    pub fn read_dequant<B: ReadBitsLtr>(&self, bs: &mut B) -> std::io::Result<(f32, f32)> {
+    pub fn read_dequant<B: ReadBitsLtr>(&self, bs: &mut B) -> Result<(f32, f32)> {
         bs.read_codebook(&self.codebook).map(|(cw, _)| self.values[cw as usize])
     }
 }
@@ -543,7 +544,7 @@ pub struct EscapeCodebook {
 
 impl EscapeCodebook {
     #[inline(always)]
-    pub fn read_quant<B: ReadBitsLtr>(&self, bs: &mut B) -> std::io::Result<(u16, u16)> {
+    pub fn read_quant<B: ReadBitsLtr>(&self, bs: &mut B) -> Result<(u16, u16)> {
         bs.read_codebook(&self.codebook).map(|(cw, _)| self.values[cw as usize])
     }
 }

--- a/symphonia-codec-vorbis/src/floor.rs
+++ b/symphonia-codec-vorbis/src/floor.rs
@@ -89,10 +89,9 @@ macro_rules! io_try_or_ret {
     ($expr:expr) => {
         match $expr {
             Ok(val) => val,
-            // An end-of-bitstream error is classified under ErrorKind::Other. This condition
-            // should not be treated as an error, rather, it should return from the function
-            // immediately without error.
-            Err(ref e) if e.kind() == std::io::ErrorKind::Other => return Ok(()),
+            // This condition should not be treated as an error, rather,
+            // it should return from the function immediately without error.
+            Err(symphonia_core::errors::Error::EndOfBitstream) => return Ok(()),
             Err(e) => return Err(e.into()),
         }
     };

--- a/symphonia-core/src/errors.rs
+++ b/symphonia-core/src/errors.rs
@@ -54,6 +54,16 @@ pub enum Error {
     LimitError(&'static str),
     /// The demuxer or decoder needs to be reset before continuing.
     ResetRequired,
+
+    BufferUnderrun,
+
+    EndOfBitstream,
+
+    OutOfBounds,
+
+    UnexpectedEof,
+
+    Other(&'static str),
 }
 
 impl fmt::Display for Error {
@@ -75,6 +85,21 @@ impl fmt::Display for Error {
             Error::ResetRequired => {
                 write!(f, "decoder needs to be reset")
             }
+            Error::BufferUnderrun => {
+                write!(f, "buffer underrun")
+            }
+            Error::EndOfBitstream => {
+                write!(f, "end of bitstream")
+            }
+            Error::OutOfBounds => {
+                write!(f, "out of bounds")
+            }
+            Error::Other(msg) => {
+                write!(f, "{}", msg)
+            }
+            Error::UnexpectedEof => {
+                write!(f, "unexpected end of file")
+            }
         }
     }
 }
@@ -88,7 +113,18 @@ impl std::error::Error for Error {
             Error::Unsupported(_) => None,
             Error::LimitError(_) => None,
             Error::ResetRequired => None,
+            Error::BufferUnderrun => None,
+            Error::EndOfBitstream => None,
+            Error::OutOfBounds => None,
+            Error::Other(_) => None,
+            Error::UnexpectedEof => None,
         }
+    }
+}
+
+impl From<Error> for std::io::Error {
+    fn from(value: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, value)
     }
 }
 

--- a/symphonia-core/src/io/bit.rs
+++ b/symphonia-core/src/io/bit.rs
@@ -6,24 +6,24 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::cmp::min;
-use std::io;
 
 use crate::io::ReadBytes;
 use crate::util::bits::*;
+use crate::Result;
 
-fn end_of_bitstream_error<T>() -> io::Result<T> {
-    Err(io::Error::new(io::ErrorKind::Other, "unexpected end of bitstream"))
+fn end_of_bitstream_error<T>() -> Result<T> {
+    Err(crate::errors::Error::EndOfBitstream)
 }
 
 pub mod vlc {
     //! The `vlc` module provides support for decoding variable-length codes (VLC).
 
+    use crate::Result;
     use std::cmp::max;
     use std::collections::{BTreeMap, VecDeque};
-    use std::io;
 
-    fn codebook_error<T>(desc: &'static str) -> io::Result<T> {
-        Err(io::Error::new(io::ErrorKind::Other, desc))
+    fn codebook_error<T>(desc: &'static str) -> Result<T> {
+        Err(crate::errors::Error::Other(desc))
     }
 
     /// `BitOrder` describes the relationship between the order of bits in the provided codewords
@@ -297,7 +297,7 @@ pub mod vlc {
             bit_order: BitOrder,
             is_sparse: bool,
             blocks: &[CodebookBlock<E>],
-        ) -> io::Result<Vec<E>> {
+        ) -> Result<Vec<E>> {
             // The codebook table.
             let mut table = Vec::new();
 
@@ -434,7 +434,7 @@ pub mod vlc {
             code_words: &[u32],
             code_lens: &[u8],
             values: &[E::ValueType],
-        ) -> io::Result<Codebook<E>> {
+        ) -> Result<Codebook<E>> {
             assert!(code_words.len() == code_lens.len());
             assert!(code_words.len() == values.len());
 
@@ -522,14 +522,14 @@ pub mod vlc {
 }
 
 mod private {
-    use std::io;
+    use crate::Result;
 
     pub trait FetchBitsLtr {
         /// Discard any remaining bits in the source and fetch new bits.
-        fn fetch_bits(&mut self) -> io::Result<()>;
+        fn fetch_bits(&mut self) -> Result<()>;
 
         /// Fetch new bits, and append them after the remaining bits.
-        fn fetch_bits_partial(&mut self) -> io::Result<()>;
+        fn fetch_bits_partial(&mut self) -> Result<()>;
 
         /// Get all the bits in the source.
         fn get_bits(&self) -> u64;
@@ -543,10 +543,10 @@ mod private {
 
     pub trait FetchBitsRtl {
         /// Discard any remaining bits in the source and fetch new bits.
-        fn fetch_bits(&mut self) -> io::Result<()>;
+        fn fetch_bits(&mut self) -> Result<()>;
 
         /// Fetch new bits, and append them after the remaining bits.
-        fn fetch_bits_partial(&mut self) -> io::Result<()>;
+        fn fetch_bits_partial(&mut self) -> Result<()>;
 
         /// Get all the bits in the source.
         fn get_bits(&self) -> u64;
@@ -576,7 +576,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Ignores the specified number of bits from the stream or returns an error.
     #[inline(always)]
-    fn ignore_bits(&mut self, mut num_bits: u32) -> io::Result<()> {
+    fn ignore_bits(&mut self, mut num_bits: u32) -> Result<()> {
         if num_bits <= self.num_bits_left() {
             self.consume_bits(num_bits);
         }
@@ -599,13 +599,13 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Ignores one bit from the stream or returns an error.
     #[inline(always)]
-    fn ignore_bit(&mut self) -> io::Result<()> {
+    fn ignore_bit(&mut self) -> Result<()> {
         self.ignore_bits(1)
     }
 
     /// Read a single bit as a boolean value or returns an error.
     #[inline(always)]
-    fn read_bool(&mut self) -> io::Result<bool> {
+    fn read_bool(&mut self) -> Result<bool> {
         if self.num_bits_left() < 1 {
             self.fetch_bits()?;
         }
@@ -618,7 +618,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Reads and returns a single bit or returns an error.
     #[inline(always)]
-    fn read_bit(&mut self) -> io::Result<u32> {
+    fn read_bit(&mut self) -> Result<u32> {
         if self.num_bits_left() < 1 {
             self.fetch_bits()?;
         }
@@ -632,7 +632,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Reads and returns up to 32-bits or returns an error.
     #[inline(always)]
-    fn read_bits_leq32(&mut self, mut bit_width: u32) -> io::Result<u32> {
+    fn read_bits_leq32(&mut self, mut bit_width: u32) -> Result<u32> {
         debug_assert!(bit_width <= u32::BITS);
 
         // Shift in two 32-bit operations instead of a single 64-bit operation to avoid panicing
@@ -658,14 +658,14 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
     /// Reads up to 32-bits and interprets them as a signed two's complement integer or returns an
     /// error.
     #[inline(always)]
-    fn read_bits_leq32_signed(&mut self, bit_width: u32) -> io::Result<i32> {
+    fn read_bits_leq32_signed(&mut self, bit_width: u32) -> Result<i32> {
         let value = self.read_bits_leq32(bit_width)?;
         Ok(sign_extend_leq32_to_i32(value, bit_width))
     }
 
     /// Reads and returns up to 64-bits or returns an error.
     #[inline(always)]
-    fn read_bits_leq64(&mut self, mut bit_width: u32) -> io::Result<u64> {
+    fn read_bits_leq64(&mut self, mut bit_width: u32) -> Result<u64> {
         debug_assert!(bit_width <= u64::BITS);
 
         // Hard-code the bit_width == 0 case as it's not possible to handle both the bit_width == 0
@@ -699,14 +699,14 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
     /// Reads up to 64-bits and interprets them as a signed two's complement integer or returns an
     /// error.
     #[inline(always)]
-    fn read_bits_leq64_signed(&mut self, bit_width: u32) -> io::Result<i64> {
+    fn read_bits_leq64_signed(&mut self, bit_width: u32) -> Result<i64> {
         let value = self.read_bits_leq64(bit_width)?;
         Ok(sign_extend_leq64_to_i64(value, bit_width))
     }
 
     /// Reads and returns a unary zeros encoded integer or an error.
     #[inline(always)]
-    fn read_unary_zeros(&mut self) -> io::Result<u32> {
+    fn read_unary_zeros(&mut self) -> Result<u32> {
         let mut num = 0;
 
         loop {
@@ -739,7 +739,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Reads and returns a unary zeros encoded integer that is capped to a maximum value.
     #[inline(always)]
-    fn read_unary_zeros_capped(&mut self, mut limit: u32) -> io::Result<u32> {
+    fn read_unary_zeros_capped(&mut self, mut limit: u32) -> Result<u32> {
         let mut num = 0;
 
         loop {
@@ -776,7 +776,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Reads and returns a unary ones encoded integer or an error.
     #[inline(always)]
-    fn read_unary_ones(&mut self) -> io::Result<u32> {
+    fn read_unary_ones(&mut self) -> Result<u32> {
         // Note: This algorithm is identical to read_unary_zeros except flipped for 1s.
         let mut num = 0;
 
@@ -802,7 +802,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
 
     /// Reads and returns a unary ones encoded integer that is capped to a maximum value.
     #[inline(always)]
-    fn read_unary_ones_capped(&mut self, mut limit: u32) -> io::Result<u32> {
+    fn read_unary_ones_capped(&mut self, mut limit: u32) -> Result<u32> {
         // Note: This algorithm is identical to read_unary_zeros_capped except flipped for 1s.
         let mut num = 0;
 
@@ -838,7 +838,7 @@ pub trait ReadBitsLtr: private::FetchBitsLtr {
     fn read_codebook<E: vlc::CodebookEntry>(
         &mut self,
         codebook: &vlc::Codebook<E>,
-    ) -> io::Result<(E::ValueType, u32)> {
+    ) -> Result<(E::ValueType, u32)> {
         // Attempt refill the bit buffer with enough bits for the longest codeword in the codebook.
         // However, this does not mean the bit buffer will have enough bits to decode a codeword.
         if self.num_bits_left() < codebook.max_code_len {
@@ -907,14 +907,14 @@ impl<'a, B: ReadBytes> BitStreamLtr<'a, B> {
 
 impl<B: ReadBytes> private::FetchBitsLtr for BitStreamLtr<'_, B> {
     #[inline(always)]
-    fn fetch_bits(&mut self) -> io::Result<()> {
+    fn fetch_bits(&mut self) -> Result<()> {
         self.bits = u64::from(self.reader.read_u8()?) << 56;
         self.n_bits_left = u8::BITS;
         Ok(())
     }
 
     #[inline(always)]
-    fn fetch_bits_partial(&mut self) -> io::Result<()> {
+    fn fetch_bits_partial(&mut self) -> Result<()> {
         todo!()
     }
 
@@ -956,7 +956,7 @@ impl<'a> BitReaderLtr<'a> {
 
 impl private::FetchBitsLtr for BitReaderLtr<'_> {
     #[inline]
-    fn fetch_bits_partial(&mut self) -> io::Result<()> {
+    fn fetch_bits_partial(&mut self) -> Result<()> {
         let mut buf = [0u8; std::mem::size_of::<u64>()];
 
         let read_len = min(self.buf.len(), (u64::BITS - self.n_bits_left) as usize >> 3);
@@ -971,7 +971,7 @@ impl private::FetchBitsLtr for BitReaderLtr<'_> {
         Ok(())
     }
 
-    fn fetch_bits(&mut self) -> io::Result<()> {
+    fn fetch_bits(&mut self) -> Result<()> {
         let mut buf = [0u8; std::mem::size_of::<u64>()];
 
         let read_len = min(self.buf.len(), std::mem::size_of::<u64>());
@@ -1026,7 +1026,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Ignores the specified number of bits from the stream or returns an error.
     #[inline(always)]
-    fn ignore_bits(&mut self, mut num_bits: u32) -> io::Result<()> {
+    fn ignore_bits(&mut self, mut num_bits: u32) -> Result<()> {
         if num_bits <= self.num_bits_left() {
             self.consume_bits(num_bits);
         }
@@ -1049,13 +1049,13 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Ignores one bit from the stream or returns an error.
     #[inline(always)]
-    fn ignore_bit(&mut self) -> io::Result<()> {
+    fn ignore_bit(&mut self) -> Result<()> {
         self.ignore_bits(1)
     }
 
     /// Read a single bit as a boolean value or returns an error.
     #[inline(always)]
-    fn read_bool(&mut self) -> io::Result<bool> {
+    fn read_bool(&mut self) -> Result<bool> {
         if self.num_bits_left() < 1 {
             self.fetch_bits()?;
         }
@@ -1068,7 +1068,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Reads and returns a single bit or returns an error.
     #[inline(always)]
-    fn read_bit(&mut self) -> io::Result<u32> {
+    fn read_bit(&mut self) -> Result<u32> {
         if self.num_bits_left() < 1 {
             self.fetch_bits()?;
         }
@@ -1082,7 +1082,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Reads and returns up to 32-bits or returns an error.
     #[inline(always)]
-    fn read_bits_leq32(&mut self, bit_width: u32) -> io::Result<u32> {
+    fn read_bits_leq32(&mut self, bit_width: u32) -> Result<u32> {
         debug_assert!(bit_width <= u32::BITS);
 
         let mut bits = self.get_bits();
@@ -1107,14 +1107,14 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
     /// Reads up to 32-bits and interprets them as a signed two's complement integer or returns an
     /// error.
     #[inline(always)]
-    fn read_bits_leq32_signed(&mut self, bit_width: u32) -> io::Result<i32> {
+    fn read_bits_leq32_signed(&mut self, bit_width: u32) -> Result<i32> {
         let value = self.read_bits_leq32(bit_width)?;
         Ok(sign_extend_leq32_to_i32(value, bit_width))
     }
 
     /// Reads and returns up to 64-bits or returns an error.
     #[inline(always)]
-    fn read_bits_leq64(&mut self, bit_width: u32) -> io::Result<u64> {
+    fn read_bits_leq64(&mut self, bit_width: u32) -> Result<u64> {
         debug_assert!(bit_width <= u64::BITS);
 
         // Hard-code the bit_width == 0 case as it's not possible to handle both the bit_width == 0
@@ -1152,14 +1152,14 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
     /// Reads up to 64-bits and interprets them as a signed two's complement integer or returns an
     /// error.
     #[inline(always)]
-    fn read_bits_leq64_signed(&mut self, bit_width: u32) -> io::Result<i64> {
+    fn read_bits_leq64_signed(&mut self, bit_width: u32) -> Result<i64> {
         let value = self.read_bits_leq64(bit_width)?;
         Ok(sign_extend_leq64_to_i64(value, bit_width))
     }
 
     /// Reads and returns a unary zeros encoded integer or an error.
     #[inline(always)]
-    fn read_unary_zeros(&mut self) -> io::Result<u32> {
+    fn read_unary_zeros(&mut self) -> Result<u32> {
         let mut num = 0;
 
         loop {
@@ -1192,7 +1192,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Reads and returns a unary zeros encoded integer that is capped to a maximum value.
     #[inline(always)]
-    fn read_unary_zeros_capped(&mut self, mut limit: u32) -> io::Result<u32> {
+    fn read_unary_zeros_capped(&mut self, mut limit: u32) -> Result<u32> {
         let mut num = 0;
 
         loop {
@@ -1229,7 +1229,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Reads and returns a unary ones encoded integer or an error.
     #[inline(always)]
-    fn read_unary_ones(&mut self) -> io::Result<u32> {
+    fn read_unary_ones(&mut self) -> Result<u32> {
         // Note: This algorithm is identical to read_unary_zeros except flipped for 1s.
         let mut num = 0;
 
@@ -1255,7 +1255,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
 
     /// Reads and returns a unary ones encoded integer or an error.
     #[inline(always)]
-    fn read_unary_ones_capped(&mut self, mut limit: u32) -> io::Result<u32> {
+    fn read_unary_ones_capped(&mut self, mut limit: u32) -> Result<u32> {
         // Note: This algorithm is identical to read_unary_zeros_capped except flipped for 1s.
         let mut num = 0;
 
@@ -1289,7 +1289,7 @@ pub trait ReadBitsRtl: private::FetchBitsRtl {
     fn read_codebook<E: vlc::CodebookEntry>(
         &mut self,
         codebook: &vlc::Codebook<E>,
-    ) -> io::Result<(E::ValueType, u32)> {
+    ) -> Result<(E::ValueType, u32)> {
         if self.num_bits_left() < codebook.max_code_len {
             self.fetch_bits_partial()?;
         }
@@ -1356,14 +1356,14 @@ impl<'a, B: ReadBytes> BitStreamRtl<'a, B> {
 
 impl<B: ReadBytes> private::FetchBitsRtl for BitStreamRtl<'_, B> {
     #[inline(always)]
-    fn fetch_bits(&mut self) -> io::Result<()> {
+    fn fetch_bits(&mut self) -> Result<()> {
         self.bits = u64::from(self.reader.read_u8()?);
         self.n_bits_left = u8::BITS;
         Ok(())
     }
 
     #[inline(always)]
-    fn fetch_bits_partial(&mut self) -> io::Result<()> {
+    fn fetch_bits_partial(&mut self) -> Result<()> {
         todo!()
     }
 
@@ -1405,7 +1405,7 @@ impl<'a> BitReaderRtl<'a> {
 
 impl private::FetchBitsRtl for BitReaderRtl<'_> {
     #[inline]
-    fn fetch_bits_partial(&mut self) -> io::Result<()> {
+    fn fetch_bits_partial(&mut self) -> Result<()> {
         let mut buf = [0u8; std::mem::size_of::<u64>()];
 
         let read_len = min(self.buf.len(), (u64::BITS - self.n_bits_left) as usize >> 3);
@@ -1420,7 +1420,7 @@ impl private::FetchBitsRtl for BitReaderRtl<'_> {
         Ok(())
     }
 
-    fn fetch_bits(&mut self) -> io::Result<()> {
+    fn fetch_bits(&mut self) -> Result<()> {
         let mut buf = [0u8; std::mem::size_of::<u64>()];
 
         let read_len = min(self.buf.len(), std::mem::size_of::<u64>());

--- a/symphonia-core/src/io/buf_reader.rs
+++ b/symphonia-core/src/io/buf_reader.rs
@@ -5,14 +5,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::Result;
 use std::cmp;
-use std::io;
 
 use super::{FiniteStream, ReadBytes};
 
 #[inline(always)]
-fn underrun_error<T>() -> io::Result<T> {
-    Err(io::Error::new(io::ErrorKind::UnexpectedEof, "buffer underrun"))
+fn underrun_error<T>() -> Result<T> {
+    Err(crate::errors::Error::BufferUnderrun)
 }
 
 /// A `BufReader` reads bytes from a byte buffer.
@@ -33,7 +33,7 @@ impl<'a> BufReader<'a> {
     /// if the underlying buffer is exhausted before matching the pattern, remainder of the buffer
     /// is returned.
     #[inline(always)]
-    pub fn scan_bytes_ref(&mut self, pattern: &[u8], scan_len: usize) -> io::Result<&'a [u8]> {
+    pub fn scan_bytes_ref(&mut self, pattern: &[u8], scan_len: usize) -> Result<&'a [u8]> {
         self.scan_bytes_aligned_ref(pattern, 1, scan_len)
     }
 
@@ -44,7 +44,7 @@ impl<'a> BufReader<'a> {
         pattern: &[u8],
         align: usize,
         scan_len: usize,
-    ) -> io::Result<&'a [u8]> {
+    ) -> Result<&'a [u8]> {
         // The pattern must be atleast one byte.
         debug_assert!(!pattern.is_empty());
 
@@ -77,7 +77,7 @@ impl<'a> BufReader<'a> {
     }
 
     /// Returns a reference to the next `len` bytes in the buffer and advances the stream.
-    pub fn read_buf_bytes_ref(&mut self, len: usize) -> io::Result<&'a [u8]> {
+    pub fn read_buf_bytes_ref(&mut self, len: usize) -> Result<&'a [u8]> {
         if self.pos + len > self.buf.len() {
             return underrun_error();
         }
@@ -95,7 +95,7 @@ impl<'a> BufReader<'a> {
 
 impl ReadBytes for BufReader<'_> {
     #[inline(always)]
-    fn read_byte(&mut self) -> io::Result<u8> {
+    fn read_byte(&mut self) -> Result<u8> {
         if self.buf.len() - self.pos < 1 {
             return underrun_error();
         }
@@ -105,7 +105,7 @@ impl ReadBytes for BufReader<'_> {
     }
 
     #[inline(always)]
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]> {
         if self.buf.len() - self.pos < 2 {
             return underrun_error();
         }
@@ -118,7 +118,7 @@ impl ReadBytes for BufReader<'_> {
     }
 
     #[inline(always)]
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]> {
         if self.buf.len() - self.pos < 3 {
             return underrun_error();
         }
@@ -131,7 +131,7 @@ impl ReadBytes for BufReader<'_> {
     }
 
     #[inline(always)]
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]> {
         if self.buf.len() - self.pos < 4 {
             return underrun_error();
         }
@@ -143,7 +143,7 @@ impl ReadBytes for BufReader<'_> {
         Ok(bytes)
     }
 
-    fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
         let len = cmp::min(self.buf.len() - self.pos, buf.len());
         buf[..len].copy_from_slice(&self.buf[self.pos..self.pos + len]);
         self.pos += len;
@@ -151,7 +151,7 @@ impl ReadBytes for BufReader<'_> {
         Ok(len)
     }
 
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         let len = buf.len();
 
         if self.buf.len() - self.pos < len {
@@ -169,14 +169,14 @@ impl ReadBytes for BufReader<'_> {
         pattern: &[u8],
         align: usize,
         buf: &'b mut [u8],
-    ) -> io::Result<&'b mut [u8]> {
+    ) -> Result<&'b mut [u8]> {
         let scanned = self.scan_bytes_aligned_ref(pattern, align, buf.len())?;
         buf[..scanned.len()].copy_from_slice(scanned);
 
         Ok(&mut buf[..scanned.len()])
     }
 
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()> {
+    fn ignore_bytes(&mut self, count: u64) -> Result<()> {
         if self.buf.len() - self.pos < count as usize {
             return underrun_error();
         }

--- a/symphonia-core/src/io/mod.rs
+++ b/symphonia-core/src/io/mod.rs
@@ -28,6 +28,7 @@ mod media_source_stream;
 mod monitor_stream;
 mod scoped_stream;
 
+use crate::Result;
 pub use bit::*;
 pub use buf_reader::BufReader;
 pub use media_source_stream::{MediaSourceStream, MediaSourceStreamOptions};
@@ -144,67 +145,67 @@ impl<R: io::Read> io::Seek for ReadOnlySource<R> {
 /// unsigned integers or floating-point values of standard widths.
 pub trait ReadBytes {
     /// Reads a single byte from the stream and returns it or an error.
-    fn read_byte(&mut self) -> io::Result<u8>;
+    fn read_byte(&mut self) -> Result<u8>;
 
     /// Reads two bytes from the stream and returns them in read-order or an error.
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]>;
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]>;
 
     /// Reads three bytes from the stream and returns them in read-order or an error.
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]>;
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]>;
 
     /// Reads four bytes from the stream and returns them in read-order or an error.
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]>;
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]>;
 
     /// Reads up-to the number of bytes required to fill buf or returns an error.
-    fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize>;
 
     /// Reads exactly the number of bytes required to fill be provided buffer or returns an error.
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()>;
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()>;
 
     /// Reads a single unsigned byte from the stream and returns it or an error.
     #[inline(always)]
-    fn read_u8(&mut self) -> io::Result<u8> {
+    fn read_u8(&mut self) -> Result<u8> {
         self.read_byte()
     }
 
     /// Reads a single signed byte from the stream and returns it or an error.
     #[inline(always)]
-    fn read_i8(&mut self) -> io::Result<i8> {
+    fn read_i8(&mut self) -> Result<i8> {
         Ok(self.read_byte()? as i8)
     }
 
     /// Reads two bytes from the stream and interprets them as an unsigned 16-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_u16(&mut self) -> io::Result<u16> {
+    fn read_u16(&mut self) -> Result<u16> {
         Ok(u16::from_le_bytes(self.read_double_bytes()?))
     }
 
     /// Reads two bytes from the stream and interprets them as an signed 16-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_i16(&mut self) -> io::Result<i16> {
+    fn read_i16(&mut self) -> Result<i16> {
         Ok(i16::from_le_bytes(self.read_double_bytes()?))
     }
 
     /// Reads two bytes from the stream and interprets them as an unsigned 16-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_u16(&mut self) -> io::Result<u16> {
+    fn read_be_u16(&mut self) -> Result<u16> {
         Ok(u16::from_be_bytes(self.read_double_bytes()?))
     }
 
     /// Reads two bytes from the stream and interprets them as an signed 16-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_i16(&mut self) -> io::Result<i16> {
+    fn read_be_i16(&mut self) -> Result<i16> {
         Ok(i16::from_be_bytes(self.read_double_bytes()?))
     }
 
     /// Reads three bytes from the stream and interprets them as an unsigned 24-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_u24(&mut self) -> io::Result<u32> {
+    fn read_u24(&mut self) -> Result<u32> {
         let mut buf = [0u8; mem::size_of::<u32>()];
         buf[0..3].clone_from_slice(&self.read_triple_bytes()?);
         Ok(u32::from_le_bytes(buf))
@@ -213,14 +214,14 @@ pub trait ReadBytes {
     /// Reads three bytes from the stream and interprets them as an signed 24-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_i24(&mut self) -> io::Result<i32> {
+    fn read_i24(&mut self) -> Result<i32> {
         Ok(((self.read_u24()? << 8) as i32) >> 8)
     }
 
     /// Reads three bytes from the stream and interprets them as an unsigned 24-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_u24(&mut self) -> io::Result<u32> {
+    fn read_be_u24(&mut self) -> Result<u32> {
         let mut buf = [0u8; mem::size_of::<u32>()];
         buf[0..3].clone_from_slice(&self.read_triple_bytes()?);
         Ok(u32::from_be_bytes(buf) >> 8)
@@ -229,42 +230,42 @@ pub trait ReadBytes {
     /// Reads three bytes from the stream and interprets them as an signed 24-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_i24(&mut self) -> io::Result<i32> {
+    fn read_be_i24(&mut self) -> Result<i32> {
         Ok(((self.read_be_u24()? << 8) as i32) >> 8)
     }
 
     /// Reads four bytes from the stream and interprets them as an unsigned 32-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_u32(&mut self) -> io::Result<u32> {
+    fn read_u32(&mut self) -> Result<u32> {
         Ok(u32::from_le_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads four bytes from the stream and interprets them as an signed 32-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_i32(&mut self) -> io::Result<i32> {
+    fn read_i32(&mut self) -> Result<i32> {
         Ok(i32::from_le_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads four bytes from the stream and interprets them as an unsigned 32-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_u32(&mut self) -> io::Result<u32> {
+    fn read_be_u32(&mut self) -> Result<u32> {
         Ok(u32::from_be_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads four bytes from the stream and interprets them as a signed 32-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_i32(&mut self) -> io::Result<i32> {
+    fn read_be_i32(&mut self) -> Result<i32> {
         Ok(i32::from_be_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads eight bytes from the stream and interprets them as an unsigned 64-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_u64(&mut self) -> io::Result<u64> {
+    fn read_u64(&mut self) -> Result<u64> {
         let mut buf = [0u8; mem::size_of::<u64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(u64::from_le_bytes(buf))
@@ -273,7 +274,7 @@ pub trait ReadBytes {
     /// Reads eight bytes from the stream and interprets them as an signed 64-bit little-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_i64(&mut self) -> io::Result<i64> {
+    fn read_i64(&mut self) -> Result<i64> {
         let mut buf = [0u8; mem::size_of::<i64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(i64::from_le_bytes(buf))
@@ -282,7 +283,7 @@ pub trait ReadBytes {
     /// Reads eight bytes from the stream and interprets them as an unsigned 64-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_u64(&mut self) -> io::Result<u64> {
+    fn read_be_u64(&mut self) -> Result<u64> {
         let mut buf = [0u8; mem::size_of::<u64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(u64::from_be_bytes(buf))
@@ -291,7 +292,7 @@ pub trait ReadBytes {
     /// Reads eight bytes from the stream and interprets them as an signed 64-bit big-endian
     /// integer or returns an error.
     #[inline(always)]
-    fn read_be_i64(&mut self) -> io::Result<i64> {
+    fn read_be_i64(&mut self) -> Result<i64> {
         let mut buf = [0u8; mem::size_of::<i64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(i64::from_be_bytes(buf))
@@ -300,21 +301,21 @@ pub trait ReadBytes {
     /// Reads four bytes from the stream and interprets them as a 32-bit little-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
-    fn read_f32(&mut self) -> io::Result<f32> {
+    fn read_f32(&mut self) -> Result<f32> {
         Ok(f32::from_le_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads four bytes from the stream and interprets them as a 32-bit big-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
-    fn read_be_f32(&mut self) -> io::Result<f32> {
+    fn read_be_f32(&mut self) -> Result<f32> {
         Ok(f32::from_be_bytes(self.read_quad_bytes()?))
     }
 
     /// Reads four bytes from the stream and interprets them as a 64-bit little-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
-    fn read_f64(&mut self) -> io::Result<f64> {
+    fn read_f64(&mut self) -> Result<f64> {
         let mut buf = [0u8; mem::size_of::<u64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(f64::from_le_bytes(buf))
@@ -323,7 +324,7 @@ pub trait ReadBytes {
     /// Reads four bytes from the stream and interprets them as a 64-bit big-endian IEEE-754
     /// floating-point value.
     #[inline(always)]
-    fn read_be_f64(&mut self) -> io::Result<f64> {
+    fn read_be_f64(&mut self) -> Result<f64> {
         let mut buf = [0u8; mem::size_of::<u64>()];
         self.read_buf_exact(&mut buf)?;
         Ok(f64::from_be_bytes(buf))
@@ -331,7 +332,7 @@ pub trait ReadBytes {
 
     /// Reads up-to the number of bytes requested, and returns a boxed slice of the data or an
     /// error.
-    fn read_boxed_slice(&mut self, len: usize) -> io::Result<Box<[u8]>> {
+    fn read_boxed_slice(&mut self, len: usize) -> Result<Box<[u8]>> {
         let mut buf = vec![0u8; len];
         let actual_len = self.read_buf(&mut buf)?;
         buf.truncate(actual_len);
@@ -340,7 +341,7 @@ pub trait ReadBytes {
 
     /// Reads exactly the number of bytes requested, and returns a boxed slice of the data or an
     /// error.
-    fn read_boxed_slice_exact(&mut self, len: usize) -> io::Result<Box<[u8]>> {
+    fn read_boxed_slice_exact(&mut self, len: usize) -> Result<Box<[u8]>> {
         let mut buf = vec![0u8; len];
         self.read_buf_exact(&mut buf)?;
         Ok(buf.into_boxed_slice())
@@ -349,7 +350,7 @@ pub trait ReadBytes {
     /// Reads bytes from the stream into a supplied buffer until a byte pattern is matched. Returns
     /// a mutable slice to the valid region of the provided buffer.
     #[inline(always)]
-    fn scan_bytes<'a>(&mut self, pattern: &[u8], buf: &'a mut [u8]) -> io::Result<&'a mut [u8]> {
+    fn scan_bytes<'a>(&mut self, pattern: &[u8], buf: &'a mut [u8]) -> Result<&'a mut [u8]> {
         self.scan_bytes_aligned(pattern, 1, buf)
     }
 
@@ -360,10 +361,10 @@ pub trait ReadBytes {
         pattern: &[u8],
         align: usize,
         buf: &'a mut [u8],
-    ) -> io::Result<&'a mut [u8]>;
+    ) -> Result<&'a mut [u8]>;
 
     /// Ignores the specified number of bytes from the stream or returns an error.
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()>;
+    fn ignore_bytes(&mut self, count: u64) -> Result<()>;
 
     /// Gets the position of the stream.
     fn pos(&self) -> u64;
@@ -371,32 +372,32 @@ pub trait ReadBytes {
 
 impl<R: ReadBytes> ReadBytes for &mut R {
     #[inline(always)]
-    fn read_byte(&mut self) -> io::Result<u8> {
+    fn read_byte(&mut self) -> Result<u8> {
         (*self).read_byte()
     }
 
     #[inline(always)]
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]> {
         (*self).read_double_bytes()
     }
 
     #[inline(always)]
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]> {
         (*self).read_triple_bytes()
     }
 
     #[inline(always)]
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]> {
         (*self).read_quad_bytes()
     }
 
     #[inline(always)]
-    fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
         (*self).read_buf(buf)
     }
 
     #[inline(always)]
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         (*self).read_buf_exact(buf)
     }
 
@@ -406,12 +407,12 @@ impl<R: ReadBytes> ReadBytes for &mut R {
         pattern: &[u8],
         align: usize,
         buf: &'a mut [u8],
-    ) -> io::Result<&'a mut [u8]> {
+    ) -> Result<&'a mut [u8]> {
         (*self).scan_bytes_aligned(pattern, align, buf)
     }
 
     #[inline(always)]
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()> {
+    fn ignore_bytes(&mut self, count: u64) -> Result<()> {
         (*self).ignore_bytes(count)
     }
 

--- a/symphonia-core/src/io/monitor_stream.rs
+++ b/symphonia-core/src/io/monitor_stream.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::io;
+use crate::Result;
 
 use super::ReadBytes;
 
@@ -73,40 +73,40 @@ impl<B: ReadBytes, M: Monitor> MonitorStream<B, M> {
 
 impl<B: ReadBytes, M: Monitor> ReadBytes for MonitorStream<B, M> {
     #[inline(always)]
-    fn read_byte(&mut self) -> io::Result<u8> {
+    fn read_byte(&mut self) -> Result<u8> {
         let byte = self.inner.read_byte()?;
         self.monitor.process_byte(byte);
         Ok(byte)
     }
 
     #[inline(always)]
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]> {
         let bytes = self.inner.read_double_bytes()?;
         self.monitor.process_double_bytes(bytes);
         Ok(bytes)
     }
 
     #[inline(always)]
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]> {
         let bytes = self.inner.read_triple_bytes()?;
         self.monitor.process_triple_bytes(bytes);
         Ok(bytes)
     }
 
     #[inline(always)]
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]> {
         let bytes = self.inner.read_quad_bytes()?;
         self.monitor.process_quad_bytes(bytes);
         Ok(bytes)
     }
 
-    fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
         let len = self.inner.read_buf(buf)?;
         self.monitor.process_buf_bytes(&buf[0..len]);
         Ok(len)
     }
 
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         self.inner.read_buf_exact(buf)?;
         self.monitor.process_buf_bytes(buf);
         Ok(())
@@ -117,13 +117,13 @@ impl<B: ReadBytes, M: Monitor> ReadBytes for MonitorStream<B, M> {
         pattern: &[u8],
         align: usize,
         buf: &'a mut [u8],
-    ) -> io::Result<&'a mut [u8]> {
+    ) -> Result<&'a mut [u8]> {
         let result = self.inner.scan_bytes_aligned(pattern, align, buf)?;
         self.monitor.process_buf_bytes(result);
         Ok(result)
     }
 
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()> {
+    fn ignore_bytes(&mut self, count: u64) -> Result<()> {
         self.inner.ignore_bytes(count)
     }
 

--- a/symphonia-core/src/io/scoped_stream.rs
+++ b/symphonia-core/src/io/scoped_stream.rs
@@ -5,14 +5,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::Result;
 use std::cmp;
-use std::io;
 
 use super::{FiniteStream, ReadBytes, SeekBuffered};
 
 #[inline(always)]
-fn out_of_bounds_error<T>() -> io::Result<T> {
-    Err(io::Error::new(io::ErrorKind::UnexpectedEof, "out of bounds"))
+fn out_of_bounds_error<T>() -> Result<T> {
+    Err(crate::errors::Error::OutOfBounds)
 }
 
 /// A `ScopedStream` restricts the number of bytes that may be read to an upper limit.
@@ -41,7 +41,7 @@ impl<B: ReadBytes> ScopedStream<B> {
     }
 
     /// Ignores the remainder of the `ScopedStream`.
-    pub fn ignore(&mut self) -> io::Result<()> {
+    pub fn ignore(&mut self) -> Result<()> {
         self.inner.ignore_bytes(self.len - self.read)
     }
 
@@ -70,7 +70,7 @@ impl<B: ReadBytes> FiniteStream for ScopedStream<B> {
 
 impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
     #[inline(always)]
-    fn read_byte(&mut self) -> io::Result<u8> {
+    fn read_byte(&mut self) -> Result<u8> {
         if self.len - self.read < 1 {
             return out_of_bounds_error();
         }
@@ -80,7 +80,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
     }
 
     #[inline(always)]
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]> {
         if self.len - self.read < 2 {
             return out_of_bounds_error();
         }
@@ -90,7 +90,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
     }
 
     #[inline(always)]
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]> {
         if self.len - self.read < 3 {
             return out_of_bounds_error();
         }
@@ -100,7 +100,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
     }
 
     #[inline(always)]
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]> {
         if self.len - self.read < 4 {
             return out_of_bounds_error();
         }
@@ -109,7 +109,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
         self.inner.read_quad_bytes()
     }
 
-    fn read_buf(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<usize> {
         // Limit read_buf() to the remainder of the scoped bytes if buf has a greater length.
         let scoped_len = cmp::min(self.len - self.read, buf.len() as u64) as usize;
         let result = self.inner.read_buf(&mut buf[0..scoped_len])?;
@@ -117,7 +117,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
         Ok(result)
     }
 
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         if self.len - self.read < buf.len() as u64 {
             return out_of_bounds_error();
         }
@@ -132,7 +132,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
         pattern: &[u8],
         align: usize,
         buf: &'a mut [u8],
-    ) -> io::Result<&'a mut [u8]> {
+    ) -> Result<&'a mut [u8]> {
         if self.len - self.read < buf.len() as u64 {
             return out_of_bounds_error();
         }
@@ -143,7 +143,7 @@ impl<B: ReadBytes> ReadBytes for ScopedStream<B> {
     }
 
     #[inline(always)]
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()> {
+    fn ignore_bytes(&mut self, count: u64) -> Result<()> {
         if self.len - self.read < count {
             return out_of_bounds_error();
         }

--- a/symphonia-core/src/lib.rs
+++ b/symphonia-core/src/lib.rs
@@ -12,6 +12,8 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::manual_range_contains)]
 
+pub use errors::Result;
+
 pub mod audio;
 pub mod checksum;
 pub mod codecs;

--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -603,6 +603,7 @@ impl From<EbmlError> for Error {
         // All non-IO EBML errors are mapped to a decode error.
         let msg = match value {
             EbmlError::IoError(err) => return Error::IoError(err),
+            EbmlError::SymphoniaCoreError(err) => return err,
             EbmlError::InvalidEbmlElementIdLength => "mkv (ebml): invalid ebml element id length",
             EbmlError::InvalidEbmlDataLength => "mkv (ebml): invalid ebml vint length",
             EbmlError::UnknownElement => "mkv (ebml): the element is unknown",

--- a/symphonia-format-mkv/src/ebml.rs
+++ b/symphonia-format-mkv/src/ebml.rs
@@ -16,6 +16,8 @@ use symphonia_core::util::bits::sign_extend_leq64_to_i64;
 pub enum EbmlError {
     /// An IO error occured while reading, writing, or seeking the EBML document.
     IoError(std::io::Error),
+    /// An IO error occured while reading, writing, or seeking the EBML document.
+    SymphoniaCoreError(symphonia_core::errors::Error),
     /// The encoding of an EBML element ID was invalid.
     InvalidEbmlElementIdLength,
     /// The encoding of an EBML element data size was invalid.
@@ -55,6 +57,12 @@ pub enum EbmlError {
 impl From<std::io::Error> for EbmlError {
     fn from(err: std::io::Error) -> EbmlError {
         EbmlError::IoError(err)
+    }
+}
+
+impl From<symphonia_core::errors::Error> for EbmlError {
+    fn from(err: symphonia_core::errors::Error) -> Self {
+        EbmlError::SymphoniaCoreError(err)
     }
 }
 

--- a/symphonia-metadata/src/id3v2/unsync.rs
+++ b/symphonia-metadata/src/id3v2/unsync.rs
@@ -5,8 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::io;
-
 use symphonia_core::errors::Result;
 use symphonia_core::io::{FiniteStream, ReadBytes};
 
@@ -86,7 +84,7 @@ impl<B: ReadBytes + FiniteStream> FiniteStream for UnsyncStream<B> {
 }
 
 impl<B: ReadBytes + FiniteStream> ReadBytes for UnsyncStream<B> {
-    fn read_byte(&mut self) -> io::Result<u8> {
+    fn read_byte(&mut self) -> Result<u8> {
         let last = self.byte;
 
         self.byte = self.inner.read_byte()?;
@@ -100,24 +98,24 @@ impl<B: ReadBytes + FiniteStream> ReadBytes for UnsyncStream<B> {
         Ok(self.byte)
     }
 
-    fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
+    fn read_double_bytes(&mut self) -> Result<[u8; 2]> {
         Ok([self.read_byte()?, self.read_byte()?])
     }
 
-    fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
+    fn read_triple_bytes(&mut self) -> Result<[u8; 3]> {
         Ok([self.read_byte()?, self.read_byte()?, self.read_byte()?])
     }
 
-    fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
+    fn read_quad_bytes(&mut self) -> Result<[u8; 4]> {
         Ok([self.read_byte()?, self.read_byte()?, self.read_byte()?, self.read_byte()?])
     }
 
-    fn read_buf(&mut self, _: &mut [u8]) -> io::Result<usize> {
+    fn read_buf(&mut self, _: &mut [u8]) -> Result<usize> {
         // Not required.
         unimplemented!();
     }
 
-    fn read_buf_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+    fn read_buf_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         let len = buf.len();
 
         if len > 0 {
@@ -166,12 +164,12 @@ impl<B: ReadBytes + FiniteStream> ReadBytes for UnsyncStream<B> {
         _: &[u8],
         _: usize,
         _: &'a mut [u8],
-    ) -> io::Result<&'a mut [u8]> {
+    ) -> Result<&'a mut [u8]> {
         // Not required.
         unimplemented!();
     }
 
-    fn ignore_bytes(&mut self, count: u64) -> io::Result<()> {
+    fn ignore_bytes(&mut self, count: u64) -> Result<()> {
         for _ in 0..count {
             self.inner.read_byte()?;
         }


### PR DESCRIPTION
This is my attempt at reducing dependency on `std::io` in `symphonia-core` with the aim of unblocking future `no_std` compatibility. In this pull request I replaced all `io::Result` with `crate::Result`.

I intend to follow the plan laid out in the discussion here: https://github.com/pdeljanov/Symphonia/pull/244