### PR TITLE
feat: derive Eq and PartialEq for SeekMode

### DIFF
--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -54,7 +54,7 @@ pub struct SeekedTo {
 }
 
 /// `SeekMode` selects the precision of a seek.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SeekMode {
     /// Coarse seek mode is a best-effort attempt to seek to the requested position. The actual
     /// position seeked to may be before or after the requested position. Coarse seeking is an


### PR DESCRIPTION
This is useful to be able to do:

```rust
if seek_mode == SeekMode::Accurate { ... }
```

instead of the less readable:

```rust
if matches!(seek_mode, SeekMode::Accurate) { ... }
```

Ran into this as we're improving sample-accurate seeking in Rodio: https://github.com/RustAudio/rodio/pull/697