### PR TITLE
Exiting if invalid streaming content

### DIFF
--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -20,7 +20,7 @@ use crate::header::{self, MAX_MPEG_FRAME_SIZE, MPEG_HEADER_LEN};
 
 use std::io::{Seek, SeekFrom};
 
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 
 /// MPEG1 and MPEG2 audio elementary stream reader.
 ///
@@ -470,7 +470,7 @@ fn read_mpeg_frame(reader: &mut MediaSourceStream) -> Result<(FrameHeader, Vec<u
             break (header, sync);
         }
 
-        warn!("invalid mpeg audio header");
+        error!("invalid mpeg audio header");
         Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid mpeg audio header"))?
     };
 

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -471,6 +471,7 @@ fn read_mpeg_frame(reader: &mut MediaSourceStream) -> Result<(FrameHeader, Vec<u
         }
 
         warn!("invalid mpeg audio header");
+        Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid mpeg audio header"))?
     };
 
     // Allocate frame buffer.


### PR DESCRIPTION
I had to fork Symphonia and do a small change in the mpeg decoder. I am using this with https://crates.io/crates/stream-download crate. This is using Rodio and Symphonia to decode radio stream. But I am getting the `invalid mpeg audio header` warning from time to time. The streamed radio is not playing and I can't detect this erorr to restart the stream. I need o have the error propagated back to Rodio and streaming-donload stream to have it restarted. Wiht this fix it works fine in my fork. Can you include similar fir in next version please? 

The fix is related to the https://github.com/pdeljanov/Symphonia/issues/325 If you made some autodotection improvements in 0.6-dev branch its even better, but returning the errro is really necessary to handle the streaming restart. Thanks 