### PR TITLE
Add basic support for reading average bitrates

### DIFF
--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -101,6 +101,7 @@ impl FormatReader for MpaReader {
 
         params
             .for_codec(header.codec())
+            .with_average_bitrate(header.bitrate)
             .with_sample_rate(header.sample_rate)
             .with_time_base(TimeBase::new(1, header.sample_rate))
             .with_channels(header.channel_mode.channels());

--- a/symphonia-core/src/codecs.rs
+++ b/symphonia-core/src/codecs.rs
@@ -272,6 +272,9 @@ pub struct CodecParameters {
     /// The sample format of an audio sample.
     pub sample_format: Option<SampleFormat>,
 
+    /// The average number of bits in a given second of audio after decompression.
+    pub average_bitrate: Option<u32>,
+
     /// The number of bits per one decoded audio sample.
     pub bits_per_sample: Option<u32>,
 
@@ -316,6 +319,7 @@ impl CodecParameters {
             n_frames: None,
             start_ts: 0,
             sample_format: None,
+            average_bitrate: None,
             bits_per_sample: None,
             bits_per_coded_sample: None,
             channels: None,
@@ -363,6 +367,12 @@ impl CodecParameters {
     /// Provide the codec's decoded audio sample format.
     pub fn with_sample_format(&mut self, sample_format: SampleFormat) -> &mut Self {
         self.sample_format = Some(sample_format);
+        self
+    }
+
+    /// Provide the bit per sample of a decoded audio sample.
+    pub fn with_average_bitrate(&mut self, average_bitrate: u32) -> &mut Self {
+        self.average_bitrate = Some(average_bitrate);
         self
     }
 


### PR DESCRIPTION
Bitrate is seemingly missing from all song metadata in this project. Even songs that contain the bitrate in the header (alac, mp3, possibly more?) don't make this information available to the user.

This commit stores the bitrate in CodecParameters as "average_bitrate". This is because some formats like flac have a variable bitrate. It's better to provide something than to promise a constant bitrate and be technically wrong as some decoders do.

This average bitrate is currently only implemented for mp3. But possibly other codecs might want to implement it. This change is fully backwards compatible.