### PR TITLE
Backport 0.6 memory leak fix to 0.5.x

### DIFF
--- a/symphonia-core/src/io/buf_reader.rs
+++ b/symphonia-core/src/io/buf_reader.rs
@@ -57,21 +57,22 @@ impl<'a> BufReader<'a> {
         // return the remainder of the buffer or scan_length bytes, which ever is shorter, we return
         // that here.
         if remaining < pattern.len() || scan_len < pattern.len() {
+            self.pos = end;
             return Ok(&self.buf[start..end]);
         }
 
-        let mut j = start;
-        let mut i = start + pattern.len();
+        let mut i = start;
+        let mut j = start + pattern.len();
 
-        while i < end {
-            if &self.buf[j..i] == pattern {
+        while j < end {
+            if &self.buf[i..j] == pattern {
                 break;
             }
-            i += align;
             j += align;
+            i += align;
         }
 
-        self.pos = cmp::min(i, self.buf.len());
+        self.pos = cmp::min(j, self.buf.len());
         Ok(&self.buf[start..self.pos])
     }
 


### PR DESCRIPTION
fixes #379

This PR backports 0.6-only commit 31f3ffa586f5262d79ee8d6d7c6a34346a03bee5(#344) to 0.5.x (master) to fix the memory leak mentioned in #379.

I dont *think* there is a "merge block for master and divert everything to 0.6", so i hope this can be merged before 0.6, which does (to my knowledge) not have any release date (or anytime too soon).

If this PR is not merged before or not released for a 0.5.x release, it can be closed without being merged. (i hope to get it into symphonia `0.5.5` as specified in #330)

@sscobici are you ok with the way this is backported?