### PR TITLE
flac: add support for 32 bits, rfc9639 dec 2024

### DIFF
--- a/symphonia-bundle-flac/src/frame.rs
+++ b/symphonia-bundle-flac/src/frame.rs
@@ -186,6 +186,7 @@ pub fn read_frame_header<B: ReadBytes>(reader: &mut B, sync: u16) -> Result<Fram
         0x4 => Some(16),
         0x5 => Some(20),
         0x6 => Some(24),
+        0x7 => Some(32),
         _ => {
             return decode_error("flac: bits per sample set to reserved value");
         }
@@ -253,7 +254,7 @@ pub fn is_likely_frame_header(buf: &[u8]) -> bool {
     }
 
     // Reserved sample size.
-    if (buf[3] & 0x0e == 0x6) || (buf[3] & 0x0e == 0x0e) {
+    if buf[3] & 0x0e == 0x6 {
         return false;
     }
 


### PR DESCRIPTION
Adds support for 32 bits for flac, which is allowed in rfc9639 dec 2024.
Passes symphonia check - with latest ffmpeg.
Fixes: #386
