### PR TITLE
clippy: fix warnings from 0.1.87

### DIFF
--- a/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
+++ b/symphonia-bundle-mp3/src/layer3/hybrid_synthesis.rs
@@ -284,7 +284,7 @@ pub(super) fn hybrid_synthesis(
 ) {
     // The first sub-band after the rzero partition boundary is the sub-band limit. All sub-bands
     // past this are zeroed.
-    let sb_limit = (channel.rzero + 17) / 18;
+    let sb_limit = channel.rzero.div_ceil(18);
 
     // Determine the split point of long and short blocks in terms of a sub-band index.
     //

--- a/symphonia-codec-aac/src/aac/ics/tns.rs
+++ b/symphonia-codec-aac/src/aac/ics/tns.rs
@@ -167,8 +167,7 @@ impl Tns {
             for f in 0..self.n_filt[w] {
                 let top = bottom;
 
-                bottom =
-                    if top > self.coeffs[w][f].length { top - self.coeffs[w][f].length } else { 0 };
+                bottom = top.saturating_sub(self.coeffs[w][f].length);
 
                 let order = self.coeffs[w][f].order;
 

--- a/symphonia-core/src/audio/channels.rs
+++ b/symphonia-core/src/audio/channels.rs
@@ -398,7 +398,7 @@ pub mod layouts {
     //!  * `FRONT` layouts include the front left, front left-of-center, front right-of-center, and
     //!    front right channels.
     //!  * `WIDE` layouts include all channels from the `FRONT` layout plus the front center
-    //!     channel.
+    //!    channel.
     //!  * `SIDE` layouts include the side left and side right channels.
     //!  * `XPY` layouts have `X` standard (non-LFE) channels, and `Y` LFE channels.
     //!

--- a/symphonia-core/src/io/bit.rs
+++ b/symphonia-core/src/io/bit.rs
@@ -12,7 +12,7 @@ use crate::io::ReadBytes;
 use crate::util::bits::*;
 
 fn end_of_bitstream_error<T>() -> io::Result<T> {
-    Err(io::Error::new(io::ErrorKind::Other, "unexpected end of bitstream"))
+    Err(io::Error::other("unexpected end of bitstream"))
 }
 
 pub mod vlc {
@@ -23,7 +23,7 @@ pub mod vlc {
     use std::io;
 
     fn codebook_error<T>(desc: &'static str) -> io::Result<T> {
-        Err(io::Error::new(io::ErrorKind::Other, desc))
+        Err(io::Error::other(desc))
     }
 
     /// `BitOrder` describes the relationship between the order of bits in the provided codewords

--- a/symphonia-core/src/io/mod.rs
+++ b/symphonia-core/src/io/mod.rs
@@ -136,7 +136,7 @@ impl<R: io::Read> io::Read for ReadOnlySource<R> {
 
 impl<R: io::Read> io::Seek for ReadOnlySource<R> {
     fn seek(&mut self, _: io::SeekFrom) -> io::Result<u64> {
-        Err(io::Error::new(io::ErrorKind::Other, "source does not support seeking"))
+        Err(io::Error::other("source does not support seeking"))
     }
 }
 

--- a/symphonia-format-ogg/src/logical.rs
+++ b/symphonia-format-ogg/src/logical.rs
@@ -161,7 +161,7 @@ impl LogicalStream {
                 }
                 Ok(MapResult::SideData { data }) => side_data.push(data),
                 Err(e) => {
-                    warn!("mapping packet failed ({}), skipping", e.to_string())
+                    warn!("mapping packet failed ({}), skipping", e)
                 }
                 _ => (),
             }


### PR DESCRIPTION
fixes latest clippy warnings