### PR TITLE
Fix seeking on some flac file: Ignore seek points if n_frames is 0

### DIFF
--- a/symphonia-core/src/formats.rs
+++ b/symphonia-core/src/formats.rs
@@ -402,12 +402,7 @@ pub mod util {
             else if ts < last_ts {
                 // If the seek point has a timestamp less-than the last entry in the index, then the
                 // insertion point must be found. This case should rarely occur.
-
-                // TODO: Use when Rust 1.52 is stable.
-                // let i = self.points.partition_point(|p| p.frame_ts < ts);
-
-                let i =
-                    self.points.iter().position(|p| p.frame_ts > ts).unwrap_or(self.points.len());
+                let i = self.points.partition_point(|p| ts > p.frame_ts);
 
                 self.points.insert(i, seek_point);
             }


### PR DESCRIPTION
I have a problem with this [file](https://drive.google.com/file/d/1_ndRi_iRIhb83RmjJAjCWQAohxRBuLRK/view?usp=sharing) , the code will panic if seeking near the end of file.

For example that file have 28800000 sample, and if I seek to 28799999 it will panic because the index search function will return the upper with 0 byte_offset, so the end_byte_offset will become less than start_byte_offset, so the code will panic because of underflow.