### PR TITLE
Allow mid-stream starting of flac streams.

### DIFF
--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -162,9 +162,11 @@ impl FlacDecoder {
         // the stream information if provided. If neither are available, return an error.
         let bits_per_sample = if let Some(bps) = header.bits_per_sample {
             bps
-        } else if let Some(bps) = self.params.bits_per_sample {
+        }
+        else if let Some(bps) = self.params.bits_per_sample {
             bps
-        } else {
+        }
+        else {
             return decode_error("flac: bits per sample not provided");
         };
 
@@ -270,7 +272,8 @@ impl AudioDecoder for FlacDecoder {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)
-        } else {
+        }
+        else {
             Ok(self.buf.as_generic_audio_buffer_ref())
         }
     }
@@ -300,7 +303,8 @@ impl AudioDecoder for FlacDecoder {
                 }
 
                 result.verify_ok = Some(decoded == expected)
-            } else {
+            }
+            else {
                 warn!("verification requested but the expected md5 checksum was not provided");
             }
         }
@@ -490,7 +494,8 @@ fn decode_linear<B: ReadBitsLtr>(bs: &mut B, bps: u32, order: u32, buf: &mut [i3
             11..=12 => lpc::<12>(order, &qlp_coeffs, qlp_coeff_shift, buf),
             _ => lpc::<32>(order, &qlp_coeffs, qlp_coeff_shift, buf),
         };
-    } else {
+    }
+    else {
         return unsupported_error("flac: lpc shifts less than 0 are not supported");
     }
 
@@ -582,7 +587,8 @@ fn decode_rice_partition<B: ReadBitsLtr>(
             let r = bs.read_bits_leq32(rice_param)?;
             *sample = rice_signed_to_i32((q << rice_param) | r);
         }
-    } else {
+    }
+    else {
         let residual_bits = bs.read_bits_leq32(5)?;
 
         // trace!(

--- a/symphonia-bundle-flac/src/demuxer.rs
+++ b/symphonia-bundle-flac/src/demuxer.rs
@@ -64,7 +64,8 @@ impl<'s> FlacReader<'s> {
             // reader is fed a stream mid-way there is no StreamInfo block. Therefore, just read
             // all metadata blocks and handle the StreamInfo block as it comes.
             FlacReader::init_with_metadata(mss, opts)?
-        } else {
+        }
+        else {
             // If the first 4 bytes are not the FLAC stream marker, attempt to read the first
             // frame header, which will also resync the parser to the first frame.
             FlacReader::init_without_metadata(mss)?
@@ -102,7 +103,8 @@ impl<'s> FlacReader<'s> {
                     // Only a single stream information block is allowed.
                     if track.is_none() {
                         track = Some(read_stream_info_block(&mut block_stream, &mut parser)?);
-                    } else {
+                    }
+                    else {
                         return decode_error("flac: found more than one stream info block");
                     }
                 }
@@ -117,7 +119,8 @@ impl<'s> FlacReader<'s> {
                     if index.is_none() {
                         index =
                             Some(read_flac_seektable_block(&mut block_stream, header.block_len)?);
-                    } else {
+                    }
+                    else {
                         return decode_error("flac: found more than one seek table block");
                     }
                 }
@@ -132,7 +135,8 @@ impl<'s> FlacReader<'s> {
                     // since the stream information block must always be the first metadata block.
                     if let Some(tb) = track.as_ref().and_then(|track| track.time_base) {
                         chapters = Some(read_flac_cuesheet_block(&mut block_stream, tb)?);
-                    } else {
+                    }
+                    else {
                         return decode_error("flac: cuesheet block before stream info");
                     }
                 }
@@ -196,7 +200,7 @@ impl<'s> FlacReader<'s> {
             parser,
         })
     }
-    
+
     // Initialises the reader without reading any metadata blocks, but by reading a frame header.
     fn init_without_metadata(mss: MediaSourceStream<'s>) -> Result<Self> {
         let mut reader = mss;
@@ -324,7 +328,8 @@ impl FormatReader for FlacReader<'_> {
                 // seek cannot be completed.
                 if let Some(tb) = track.time_base {
                     tb.calc_timestamp(time)
-                } else {
+                }
+                else {
                     return seek_error(SeekErrorKind::Unseekable);
                 }
             }
@@ -384,11 +389,13 @@ impl FormatReader for FlacReader<'_> {
 
                 if ts < sync.ts {
                     end_byte_offset = mid_byte_offset;
-                } else if ts >= sync.ts && ts < sync.ts + sync.dur {
+                }
+                else if ts >= sync.ts && ts < sync.ts + sync.dur {
                     debug!("seeked to ts={} (delta={})", sync.ts, sync.ts as i64 - ts as i64);
 
                     return Ok(SeekedTo { track_id: 0, actual_ts: sync.ts, required_ts: ts });
-                } else {
+                }
+                else {
                     start_byte_offset = mid_byte_offset;
                 }
             }

--- a/symphonia-bundle-flac/src/parser.rs
+++ b/symphonia-bundle-flac/src/parser.rs
@@ -38,11 +38,13 @@ impl<const N: usize> MovingAverage<N> {
         if self.count >= N {
             // If greater-than N values were pushed, then all samples must be averaged.
             self.samples.iter().sum::<usize>() / N
-        } else if self.count > 0 {
+        }
+        else if self.count > 0 {
             // If less-than N values were pushed, then only the first 0..N samples need to be
             // averaged.
             self.samples.iter().take(self.count).sum::<usize>() / self.count
-        } else {
+        }
+        else {
             // No samples.
             0
         }
@@ -201,16 +203,19 @@ impl PacketBuilder {
                     self.get_max_avg_frame_size()
                 );
                 true
-            } else if first.state.total_len > self.get_max_avg_frame_size() {
+            }
+            else if first.state.total_len > self.get_max_avg_frame_size() {
                 warn!(
                     "dropping fragment: packet would exeed 4x average historical size of {} bytes",
                     self.get_max_avg_frame_size()
                 );
                 true
-            } else if self.frags.len() >= 4 {
+            }
+            else if self.frags.len() >= 4 {
                 warn!("dropping fragment: packet would exceed fragment count limit");
                 true
-            } else {
+            }
+            else {
                 false
             };
 
@@ -228,7 +233,8 @@ impl PacketBuilder {
         let (header, data) = if frag.crc_match {
             // The fragment has a CRC that matches the expected CRC.
             (frag.parse_header(), frag.data)
-        } else {
+        }
+        else {
             // The fragment does not have a CRC that matches the expected CRC.
             //
             // For each existing fragment, update its running CRC with the payload of the new
@@ -237,27 +243,28 @@ impl PacketBuilder {
             // are discarded, and all fragments from F up-to and including the new fragment are
             // merged to form a packet.
             let start = self.frags.iter_mut().position(|f| f.update(&frag));
-            
+
             if let Some(i) = start {
                 // A range of fragments has been found that forms a packet.
                 let total_len = self.frags[i].state.total_len;
-                
+
                 // debug!("merging {} fragments: total_len={}", self.frags.len() - i + 1, total_len);
-                
+
                 // Merge fragment data buffers.
                 let mut data = Vec::with_capacity(total_len);
-                
+
                 for f in self.frags[i..].iter() {
                     data.extend_from_slice(&f.data);
                 }
-                
+
                 data.extend_from_slice(&frag.data);
-                
+
                 (self.frags[i].parse_header(), data.into_boxed_slice())
-            } else {
+            }
+            else {
                 // A range of fragments has not been found that forms a packet.
                 self.push_fragment(frag);
-                
+
                 return None;
             }
         };
@@ -524,7 +531,7 @@ impl PacketParser {
     }
 
     /// Resync the reader to the start of the next frame and return
-    /// the header. Omit the strict header check as this checks against 
+    /// the header. Omit the strict header check as this checks against
     /// info from metadata which might not be available if we started mid-stream.
     pub fn find_next_header<B>(&mut self, reader: &mut B) -> Result<FrameHeader>
     where
@@ -541,7 +548,8 @@ impl PacketParser {
 
             if let Ok(header) = read_frame_header(reader, sync) {
                 break header;
-            } else {
+            }
+            else {
                 // If the header check failed, then seek to one byte past the start of the false frame
                 // and continue trying to resynchronize.
                 reader.seek_buffered(frame_pos + 1);


### PR DESCRIPTION
Related to issue: https://github.com/pdeljanov/Symphonia/issues/372

This change affects `symphonia-bundle-flac` only. It adds the ability for Symphonia to create a `FlacReader` and `FlacDecoder` when presented with a stream that starts at a random position.

Normal stream starts, i.e. when the marker "fLaC" is present, are unaffected by this change.

A new branch, `flac-skip` has been created to isolate this change, this was branched off the `dev-0.6` branch.

All checks are passing. 