### PR TITLE
Upgrade bitflags from 1.2.1 to 2.9.1

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ Thom Chiovoloni <chiovolonit@gmail.com>
 # Please keep this section sorted in ascending order.
 
 aschey [https://github.com/aschey]
+baylesj [https://github.com/baylesj]
 BlackHoleFox [https://github.com/blackholefox]
 darksv [https://github.com/darksv]
 dedobbin [https://github.com/dedobbin]

--- a/symphonia-core/Cargo.toml
+++ b/symphonia-core/Cargo.toml
@@ -29,7 +29,7 @@ opt-simd = [
 
 [dependencies]
 arrayvec = "0.7.1"
-bitflags = "1.2.1"
+bitflags = "2.9.1"
 bytemuck = "1.7"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/symphonia-core/src/audio.rs
+++ b/symphonia-core/src/audio.rs
@@ -32,7 +32,7 @@ bitflags! {
     /// The first 18 defined channels are guaranteed to be identical to those specified by
     /// Microsoft's WAVEFORMATEXTENSIBLE structure. Channels after 18 are defined by Symphonia and
     /// no order is guaranteed.
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
     pub struct Channels: u32 {
         /// Front-left (left) or the Mono channel.
         const FRONT_LEFT         = 0x0000_0001;
@@ -89,41 +89,16 @@ bitflags! {
     }
 }
 
-/// An iterator over individual channels within a `Channels` bitmask.
-pub struct ChannelsIter {
-    channels: Channels,
-}
-
-impl Iterator for ChannelsIter {
-    type Item = Channels;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if !self.channels.is_empty() {
-            let channel = Channels::from_bits_truncate(1 << self.channels.bits.trailing_zeros());
-            self.channels ^= channel;
-            Some(channel)
-        }
-        else {
-            None
-        }
-    }
-}
-
 impl Channels {
     /// Gets the number of channels.
     pub fn count(self) -> usize {
-        self.bits.count_ones() as usize
-    }
-
-    /// Gets an iterator over individual channels.
-    pub fn iter(&self) -> ChannelsIter {
-        ChannelsIter { channels: *self }
+        self.bits().count_ones() as usize
     }
 }
 
 impl fmt::Display for Channels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#032b}", self.bits)
+        write!(f, "{:#032b}", self.bits())
     }
 }
 


### PR DESCRIPTION
This patch upgrades the bitflags dependency to the latest v2 version. This upgrade includes some breaking changes, so the audio.rs file has been edited to work with the new version of the bitflags crate.

This makes managing dependencies easier downstream (I work primarily in the Chromium codebase) but also has benefits purely for Symphonia, since bitflags v2 focuses on improved safety and genericity.