### PR TITLE
mkv: include channels in codec params

### DIFF
--- a/symphonia-format-mkv/src/codecs.rs
+++ b/symphonia-format-mkv/src/codecs.rs
@@ -16,6 +16,7 @@ use symphonia_common::mpeg::video::{
 };
 use symphonia_common::xiph::audio::flac::{MetadataBlockHeader, MetadataBlockType};
 use symphonia_core::audio::sample::SampleFormat;
+use symphonia_core::audio::Channels;
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_FLAC, CODEC_ID_VORBIS};
 use symphonia_core::codecs::audio::AudioCodecParameters;
 use symphonia_core::codecs::audio::{well_known::*, AudioCodecId};
@@ -66,6 +67,7 @@ fn make_audio_codec_params(
     }
 
     codec_params.with_sample_rate(audio.sampling_frequency.round() as u32);
+    codec_params.with_channels(Channels::Discrete(audio.channels.get() as u16));
 
     let format = audio.bit_depth.and_then(|bits| match bits.get() {
         8 => Some(SampleFormat::S8),


### PR DESCRIPTION
The mkv demuxer already supports parsing the channel information, but it wasn't being added to the codec params. According to the [spec](https://www.matroska.org/technical/elements.html), there was a `ChannelPositions` element used to denote the channel positions, but it's [listed as reclaimed](https://datatracker.ietf.org/doc/draft-ietf-cellar-matroska/21/) (not in use), so I'm not sure if there's a defined way to map the specific channel positions. 

Please let me know if I missed anything. Thanks!