### PR TITLE
fix: Calculate end delay for non-seekable ogg streams

### DIFF
--- a/symphonia-format-ogg/src/physical.rs
+++ b/symphonia-format-ogg/src/physical.rs
@@ -10,7 +10,7 @@ use std::io::{Seek, SeekFrom};
 use symphonia_core::errors::Result;
 use symphonia_core::io::{MediaSourceStream, ReadBytes, ScopedStream, SeekBuffered};
 
-use super::logical::{InspectState, LogicalStream};
+use super::logical::LogicalStream;
 use super::page::*;
 
 use log::debug;
@@ -153,8 +153,6 @@ fn scan_stream_end(
 
     let mut upper_pos = None;
 
-    let mut state: InspectState = Default::default();
-
     // Read pages until the provided end position or a new physical stream starts.
     loop {
         let page = pages.page();
@@ -168,7 +166,7 @@ fn scan_stream_end(
             break;
         };
 
-        state = stream.inspect_end_page(state, &page);
+        stream.inspect_end_page(&page);
 
         // The new end of the physical stream is the position after this page.
         upper_pos = Some(scoped_reader.pos());


### PR DESCRIPTION
Resolves #404.

Currently, the end delay for ogg streams is only calculated for seekable streams. This can cause discontinuities for non-seekable streams like internet radio that are designed to play gaplessly. Calling `inspect_end_page` for every page that's read ensures the end delay is still calculated for non-seekable streams. If the end delay was calculated previously, this is a no-op because of the check for `self.end_bound.is_some()` at the beginning of `inspect_end_page`.

`InspectState` was also moved to a struct field since the value needs to persist through multiple calls to `read_page`.