### PR TITLE
Fix invalid channel count fuzzer crash

### DIFF
--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -101,9 +101,11 @@ impl FlacDecoder {
         // the stream information if provided. If neither are available, return an error.
         let bits_per_sample = if let Some(bps) = header.bits_per_sample {
             bps
-        } else if let Some(bps) = self.params.bits_per_sample {
+        }
+        else if let Some(bps) = self.params.bits_per_sample {
             bps
-        } else {
+        }
+        else {
             return decode_error("flac: bits per sample not provided");
         };
 
@@ -254,7 +256,8 @@ impl Decoder for FlacDecoder {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)
-        } else {
+        }
+        else {
             Ok(self.buf.as_audio_buffer_ref())
         }
     }
@@ -284,7 +287,8 @@ impl Decoder for FlacDecoder {
                 }
 
                 result.verify_ok = Some(decoded == expected)
-            } else {
+            }
+            else {
                 warn!("verification requested but the expected md5 checksum was not provided");
             }
         }
@@ -458,7 +462,8 @@ fn decode_linear<B: ReadBitsLtr>(bs: &mut B, bps: u32, order: u32, buf: &mut [i3
             11..=12 => lpc::<12>(order, &qlp_coeffs, qlp_coeff_shift, buf),
             _ => lpc::<32>(order, &qlp_coeffs, qlp_coeff_shift, buf),
         };
-    } else {
+    }
+    else {
         return unsupported_error("flac: lpc shifts less than 0 are not supported");
     }
 
@@ -550,7 +555,8 @@ fn decode_rice_partition<B: ReadBitsLtr>(
             let r = bs.read_bits_leq32(rice_param)?;
             *sample = rice_signed_to_i32((q << rice_param) | r);
         }
-    } else {
+    }
+    else {
         let residual_bits = bs.read_bits_leq32(5)?;
 
         // trace!(


### PR DESCRIPTION
This patch fixes a crash where a FLAC buffer with an invalid channel count causes an abort. Instead, a proper decode error is returned.

See public fuzzer bug here:
http://crbug.com/468277952