### PR TITLE
Fix build issue due to manual rotate_left impl

### DIFF
--- a/symphonia-core/src/conv.rs
+++ b/symphonia-core/src/conv.rs
@@ -67,16 +67,11 @@ pub mod dither {
                 }
             }
 
-            #[inline(always)]
-            fn rotl(x: u32, k: u32) -> u32 {
-                (x << k) | (x >> (32 - k))
-            }
-
             #[inline]
             pub fn next(&mut self) -> u32 {
                 let x = self.s[0].wrapping_add(self.s[3]);
 
-                let result = Xoshiro128pp::rotl(x, 7).wrapping_add(self.s[0]);
+                let result = x.rotate_left(7).wrapping_add(self.s[0]);
 
                 let t = self.s[1] << 9;
 
@@ -87,7 +82,7 @@ pub mod dither {
 
                 self.s[2] ^= t;
 
-                self.s[3] = Xoshiro128pp::rotl(self.s[3], 11);
+                self.s[3] = self.s[3].rotate_left(11);
 
                 result
             }


### PR DESCRIPTION
Currently, Clippy builds are unhapy due to the manual implementation of `rotate_left()`:

```
error: there is no need to manually implement bit rotation
  --> symphonia-core/src/conv.rs:72:17
   |
72 |                 (x << k) | (x >> (32 - k))
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x.rotate_left(k)`
   |
```

This patch removes the `rotl` method entirely in favor of using rotate_left() directly.