### PR TITLE
Update ADTS sync byte patterns for AAC codec 

### DIFF
--- a/symphonia-codec-aac/src/adts.rs
+++ b/symphonia-codec-aac/src/adts.rs
@@ -43,7 +43,7 @@ impl QueryDescriptor for AdtsReader {
             "Audio Data Transport Stream (native AAC)",
             &["aac"],
             &["audio/aac"],
-            &[&[0xff, 0xf1]]
+            &[&[0xff, 0xf0], &[0xff, 0xf1], &[0xff, 0xf8], &[0xff, 0xf9]]
         )]
     }
 
@@ -67,7 +67,7 @@ impl AdtsHeader {
     fn sync<B: ReadBytes>(reader: &mut B) -> Result<()> {
         let mut sync = 0u16;
 
-        while sync != 0xfff1 {
+        while (sync & 0xfff6) != 0xfff0 {
             sync = (sync << 8) | u16::from(reader.read_u8()?);
         }
 


### PR DESCRIPTION
This seems to fix my problems described in issue #426

Added all possible markers for adts:
- `0xFF F1` - MPEG-2, CRC present (currently the **only** one registered)
- `0xFF F9` - MPEG-2, no CRC (**missing**)
- `0xFF F0` - MPEG-4, CRC present (**missing**)
- `0xFF F8` - MPEG-4, no CRC (**missing**)

and allowed for them to pass search with:
` while (sync & 0xfff6) != 0xfff0 {`


Testing with 
`curl -svL -A "wodio-dev" 'https://radio.garden/api/ara/content/listen/La1osLvl/channel.mp3' | RUST_LOG=trace cargo run -p symphonia-play -- -
DEBUG symphonia_core::probe > found a possible format marker within [ff, f9, 5c, 80, 2a, e0, 0, 21, 1b, f, e6, af, fc, 77, ff, d2] @ 0+2 bytes.
 DEBUG symphonia_core::probe > found the format marker [ff, f9] @ 0+2 bytes.
+ -
|
| // Tracks //
|     [01] Codec:           Advanced Audio Coding (aac)
|          Sample Rate:     22050
|          Time Base:       1/22050
|          Channel(s):      2
|          Channel Map:     0b000000000000000000000000000011
:
`