### PR TITLE
Remove sample clamping from MP3 and Vorbis decoders

### DIFF
--- a/symphonia-bundle-mp3/src/synthesis.rs
+++ b/symphonia-bundle-mp3/src/synthesis.rs
@@ -322,11 +322,11 @@ pub fn synthesis(state: &mut SynthesisState, n_frames: usize, in_samples: &[f32]
             }
         }
 
-        // Clamp and copy the PCM samples from o_vec to the output buffer.
+        // Copy the PCM samples from o_vec to the output buffer.
         let offset = b << 5;
 
         for (o, s) in out[offset..offset + 32].iter_mut().zip(&o_vec) {
-            *o = s.clamp(-1.0, 1.0);
+            *o = *s;
         }
 
         // Shift the v_vec FIFO. The value v_front is the index of the 64 sample slot in v_vec

--- a/symphonia-codec-vorbis/src/dsp.rs
+++ b/symphonia-codec-vorbis/src/dsp.rs
@@ -131,10 +131,6 @@ impl DspChannel {
                 buf[self.bs0 / 2..].copy_from_slice(&self.imdct[end..self.bs1 / 2]);
             }
 
-            // Clamp the output samples.
-            for s in buf.iter_mut() {
-                *s = s.clamp(-1.0, 1.0);
-            }
         }
 
         // Save right-half of IMDCT buffer for later.


### PR DESCRIPTION
## Summary

Remove the `[-1.0, 1.0]` sample clamping from MP3 and Vorbis decoders to align with FFmpeg behavior and enable accurate peak detection for audio analysis tools.

## Background

As discussed in #433:

- **FFmpeg (the de facto standard) does not clamp decoder output** - clipping only occurs when converting to integer formats
- The **AAC decoder in Symphonia already does not clamp**, so this change makes behavior consistent across codecs
- Clamping prevents accurate peak detection for audio analysis tools that need to detect clipping (samples exceeding 0 dBFS)

## Changes

| File | Change |
|------|--------|
| `symphonia-bundle-mp3/src/synthesis.rs` | Remove `clamp()` call, samples are now copied directly |
| `symphonia-codec-vorbis/src/dsp.rs` | Remove clamping loop entirely |

## Rationale

Applications that need clamped output for safe playback can easily apply clamping themselves after decoding:

```rust
for sample in buffer.iter_mut() {
    *sample = sample.clamp(-1.0, 1.0);
}
```

However, applications that need unclamped output (audio analysis, peak detection, ReplayGain calculation) cannot recover the original values if clamping is applied during decoding.

## Testing

- Built and tested with real MP3 and M4A files
- Verified decode-only playback works correctly with `symphonia-play`

Fixes #433