### PR TITLE
Fix reported zero length mp4 tracks

### DIFF
--- a/symphonia-format-isomp4/src/demuxer.rs
+++ b/symphonia-format-isomp4/src/demuxer.rs
@@ -48,7 +48,8 @@ impl TrackState {
         // write mdhd.duration=0 and rely on the stts table for actual timing.
         let duration = if trak.mdia.mdhd.duration > 0 {
             trak.mdia.mdhd.duration
-        } else {
+        }
+        else {
             trak.mdia.minf.stbl.stts.total_duration
         };
 


### PR DESCRIPTION
This is a small fix for some mp4 tracks that write out total lengths differently.  When using `ffprobe` it detects the total length of the track correctly, but symphonia doesn't.

This fix resolves this issue and aligns more with what happens within ffmpeg & other readers:

  1. [ISO/IEC 14496-12:2012/Cor 1:2013](https://b.goeswhere.com/ISO_IEC_14496-12_2015.pdf) clarifies that mdhd.duration = 0 means "the track samples described within this moov have zero duration" — it does NOT mean the full file has zero duration. This is used by ffmpeg's muxer when writing with empty_moov or fragmented  modes (https://lists.ffmpeg.org/pipermail/ffmpeg-cvslog/2014-October/082665.html).
  2. FFmpeg's own demuxer [mov.c:3656-3657](https://github.com/FFmpeg/FFmpeg/blob/a58cb16e27bc0c32906cfb3de36e4a495c0a8602/libavformat/mov.c#L3656-L3657) handles this by computing duration from the stts table entries and using it as a
  fallback/correction when mdhd.duration is unreliable.
  3. The stts.total_duration is authoritative — it's computed by summing sample_count * sample_delta for every entry, which is exactly the total decode duration of the track.
