### PR TITLE
fix(mp3): prevent subtraction with overflow when calculating seek position

### DIFF
--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -508,8 +508,8 @@ impl<'s> MpaReader<'s> {
 
         // It is preferable to return a packet with a timestamp before the requested timestamp.
         // Therefore, subtract the maximum packet size from the position found above to ensure this.
-        let seek_pos =
-            seek_pos_rel + u128::from(self.first_packet_pos) - MAX_MPEG_FRAME_SIZE as u128;
+        let seek_pos = (seek_pos_rel + u128::from(self.first_packet_pos))
+            .saturating_sub(MAX_MPEG_FRAME_SIZE as u128);
 
         // Seek the media source stream.
         self.reader.seek(SeekFrom::Start(


### PR DESCRIPTION
[this commit](https://github.com/pdeljanov/Symphonia/commit/666b2132a716dde43ebcc1e8ee897d7a3eddd03c) changed the seek position calculation from

```rust
let seek_pos = packet_pos.saturating_sub(MAX_MPEG_FRAME_SIZE) + self.first_packet_pos;
```

to

```rust
let seek_pos = seek_pos_rel + u128::from(self.first_packet_pos) - MAX_MPEG_FRAME_SIZE as u128;
```

but the latter can cause a panic when seeking near the beginning of the stream if `seek_pos_rel + first_packet_pos` <  `MAX_MPEG_FRAME_SIZE`.