### PR TITLE
feat(riff): add RF64/BW64 format support

### DIFF
--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -570,9 +570,64 @@ pub struct DataChunk {
 
 impl ParseChunk for DataChunk {
     fn parse<B: ReadBytes>(_: &mut B, _: [u8; 4], len: u32) -> Result<DataChunk> {
-        // If the length us u32::MAX, that usually indicates the file is streaming and the length
-        // is not known.
+        // If the length is u32::MAX, that usually indicates the file is streaming and the length
+        // is not known. For RF64 files, this also indicates the actual size is in the ds64 chunk.
         Ok(DataChunk { len: Some(len).filter(|&len| len != u32::MAX) })
+    }
+}
+
+/// DS64 chunk contains 64-bit sizes for RF64 files.
+/// This chunk must appear before the data chunk in RF64 files.
+/// Reference: EBU Tech 3306 - MBWF / RF64: An extended File Format for Audio.
+pub struct Ds64Chunk {
+    /// 64-bit RIFF chunk size (total file size minus 8).
+    pub riff_size: u64,
+    /// 64-bit data chunk size.
+    pub data_size: u64,
+    /// 64-bit sample/frame count (replaces fact chunk value).
+    pub sample_count: u64,
+}
+
+impl ParseChunk for Ds64Chunk {
+    fn parse<B: ReadBytes>(reader: &mut B, _tag: [u8; 4], len: u32) -> Result<Self> {
+        // ds64 fixed header: riffSize64 (8) + dataSize64 (8) + sampleCount64 (8) + tableLength (4)
+        const DS64_MIN_CHUNK_SIZE: u32 = 28;
+        // Each table entry: chunkId (4) + chunkSize64 (8)
+        const DS64_TABLE_ENTRY_SIZE: u64 = 12;
+
+        if len < DS64_MIN_CHUNK_SIZE {
+            return decode_error("wav: malformed ds64 chunk");
+        }
+
+        let riff_size = reader.read_u64()?;
+        let data_size = reader.read_u64()?;
+        let sample_count = reader.read_u64()?;
+        let table_length = reader.read_u32()?;
+
+        // Validate that the table entries fit within the declared chunk length.
+        let table_bytes = u64::from(table_length) * DS64_TABLE_ENTRY_SIZE;
+        let available_bytes = u64::from(len) - u64::from(DS64_MIN_CHUNK_SIZE);
+
+        if table_bytes > available_bytes {
+            return decode_error("wav: ds64 table exceeds chunk size");
+        }
+
+        // Skip over the table entries if present.
+        if table_length > 0 {
+            reader.ignore_bytes(table_bytes)?;
+        }
+
+        Ok(Ds64Chunk { riff_size, data_size, sample_count })
+    }
+}
+
+impl fmt::Display for Ds64Chunk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Ds64Chunk {{")?;
+        writeln!(f, "\triff_size: {},", self.riff_size)?;
+        writeln!(f, "\tdata_size: {},", self.data_size)?;
+        writeln!(f, "\tsample_count: {},", self.sample_count)?;
+        writeln!(f, "}}")
     }
 }
 
@@ -581,6 +636,7 @@ pub enum RiffWaveChunks {
     List(ChunkParser<ListChunk>),
     Fact(ChunkParser<FactChunk>),
     Data(ChunkParser<DataChunk>),
+    Ds64(ChunkParser<Ds64Chunk>),
 }
 
 macro_rules! parser {
@@ -596,6 +652,7 @@ impl ParseChunkTag for RiffWaveChunks {
             b"LIST" => parser!(RiffWaveChunks::List, ListChunk, tag, len),
             b"fact" => parser!(RiffWaveChunks::Fact, FactChunk, tag, len),
             b"data" => parser!(RiffWaveChunks::Data, DataChunk, tag, len),
+            b"ds64" => parser!(RiffWaveChunks::Ds64, Ds64Chunk, tag, len),
             _ => None,
         }
     }
@@ -818,4 +875,84 @@ fn map_amb_channel_count(count: u16) -> Result<Channels> {
         .into_boxed_slice();
 
     Ok(Channels::Custom(labels))
+}
+
+#[cfg(test)]
+mod ds64_tests {
+    use super::*;
+    use std::io::Cursor;
+    use symphonia_core::io::ReadOnlySource;
+
+    #[test]
+    fn test_ds64_chunk_parse() {
+        // ds64 chunk: riffSize=0x123456789ABCDEF0, dataSize=0x0FEDCBA987654321,
+        // sampleCount=0x0000000100000000, tableLen=0
+        let data: [u8; 28] = [
+            // riffSize64 (little-endian)
+            0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12, // dataSize64 (little-endian)
+            0x21, 0x43, 0x65, 0x87, 0xA9, 0xCB, 0xED, 0x0F,
+            // sampleCount64 (little-endian)
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // tableLength
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let source = ReadOnlySource::new(Cursor::new(data));
+        let mut reader = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let ds64 = Ds64Chunk::parse(&mut reader, *b"ds64", 28).unwrap();
+
+        assert_eq!(ds64.riff_size, 0x123456789ABCDEF0);
+        assert_eq!(ds64.data_size, 0x0FEDCBA987654321);
+        assert_eq!(ds64.sample_count, 0x0000000100000000);
+    }
+
+    #[test]
+    fn test_ds64_chunk_with_table() {
+        // ds64 chunk with 1 table entry
+        let data: [u8; 40] = [
+            // riffSize64
+            0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, // dataSize64
+            0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // sampleCount64
+            0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // tableLength = 1
+            0x01, 0x00, 0x00, 0x00, // table entry: "levl" + size
+            b'l', b'e', b'v', b'l', 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
+        ];
+
+        let source = ReadOnlySource::new(Cursor::new(data));
+        let mut reader = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let ds64 = Ds64Chunk::parse(&mut reader, *b"ds64", 40).unwrap();
+
+        assert_eq!(ds64.riff_size, 0x0000001000000000);
+        assert_eq!(ds64.data_size, 0x0000000800000000);
+        assert_eq!(ds64.sample_count, 0x1000);
+    }
+
+    #[test]
+    fn test_ds64_chunk_too_short() {
+        let data: [u8; 20] = [0u8; 20];
+
+        let source = ReadOnlySource::new(Cursor::new(data));
+        let mut reader = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let result = Ds64Chunk::parse(&mut reader, *b"ds64", 20);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ds64_table_exceeds_chunk_size() {
+        // ds64 with table_length=100 but chunk len=28 (no room for table entries)
+        let data: [u8; 28] = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // riffSize64
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // dataSize64
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sampleCount64
+            0x64, 0x00, 0x00, 0x00, // tableLength = 100
+        ];
+
+        let source = ReadOnlySource::new(Cursor::new(data));
+        let mut reader = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let result = Ds64Chunk::parse(&mut reader, *b"ds64", 28);
+        assert!(result.is_err());
+    }
 }

--- a/symphonia-format-riff/src/wave/mod.rs
+++ b/symphonia-format-riff/src/wave/mod.rs
@@ -29,8 +29,20 @@ use chunks::*;
 
 /// WAVE is actually a RIFF stream, with a "RIFF" ASCII stream marker.
 const WAVE_STREAM_MARKER: [u8; 4] = *b"RIFF";
+/// RF64 is a 64-bit extension of RIFF, with "RF64" as the stream marker.
+/// Reference: EBU Tech 3306 - MBWF / RF64: An extended File Format for Audio.
+const RF64_STREAM_MARKER: [u8; 4] = *b"RF64";
 /// A possible RIFF form is "wave".
 const WAVE_RIFF_FORM: [u8; 4] = *b"WAVE";
+
+/// Holds 64-bit size information from the ds64 chunk for RF64 files.
+#[derive(Default)]
+struct Rf64Sizes {
+    /// 64-bit data chunk size (None for standard WAV files).
+    data_size: Option<u64>,
+    /// 64-bit sample count (None for standard WAV or if not provided).
+    sample_count: Option<u64>,
+}
 
 const WAVE_FORMAT_INFO: FormatInfo = FormatInfo {
     format: FORMAT_ID_WAVE,
@@ -62,17 +74,20 @@ impl<'s> WavReader<'s> {
         // A Wave file is one large RIFF chunk, with the actual meta and audio data contained in
         // nested chunks. Therefore, the file starts with a RIFF chunk header (chunk ID & size).
 
-        // The top-level chunk has the RIFF chunk ID. This is also the file marker.
+        // The top-level chunk has the RIFF or RF64 chunk ID. This is also the file marker.
         let marker = mss.read_quad_bytes()?;
 
-        if marker != WAVE_STREAM_MARKER {
-            return unsupported_error("wav: missing wave riff stream marker");
-        }
+        let is_rf64 = match marker {
+            WAVE_STREAM_MARKER => false,
+            RF64_STREAM_MARKER => true,
+            _ => return unsupported_error("wav: missing riff/rf64 stream marker"),
+        };
 
         // The length of the top-level RIFF chunk. Must be atleast 4 bytes.
+        // For RF64 files, this is 0xFFFFFFFF and the actual size is in the ds64 chunk.
         let riff_len = mss.read_u32()?;
 
-        if riff_len < 4 {
+        if riff_len < 4 && riff_len != u32::MAX {
             return decode_error("wav: invalid riff length");
         }
 
@@ -86,7 +101,8 @@ impl<'s> WavReader<'s> {
         }
 
         // When ffmpeg encodes wave to stdout the riff (parent) and data (child) chunk lengths are
-        // (2^32)-1 since the size is not known ahead of time.
+        // (2^32)-1 since the size is not known ahead of time. For RF64 files, the riff length is
+        // also 0xFFFFFFFF.
         let riff_data_len = if riff_len < u32::MAX { Some(riff_len - 4) } else { None };
 
         let mut riff_chunks =
@@ -96,6 +112,7 @@ impl<'s> WavReader<'s> {
         let mut metadata: MetadataLog = Default::default();
         let mut packet_info = None;
         let mut fact = None;
+        let mut rf64_sizes = Rf64Sizes::default();
 
         loop {
             let chunk = riff_chunks.next(&mut mss)?;
@@ -107,6 +124,25 @@ impl<'s> WavReader<'s> {
             }
 
             match chunk.unwrap() {
+                RiffWaveChunks::Ds64(ds64_parser) => {
+                    let ds64 = ds64_parser.parse(&mut mss)?;
+
+                    // ds64 chunk is only meaningful in RF64 files. Ignore in standard WAV.
+                    if !is_rf64 {
+                        debug!("ignoring ds64 chunk in non-RF64 file");
+                        continue;
+                    }
+
+                    debug!(
+                        "parsed ds64 chunk: data_size={}, sample_count={}",
+                        ds64.data_size, ds64.sample_count
+                    );
+
+                    rf64_sizes.data_size = Some(ds64.data_size);
+                    if ds64.sample_count > 0 {
+                        rf64_sizes.sample_count = Some(ds64.sample_count);
+                    }
+                }
                 RiffWaveChunks::Format(fmt) => {
                     let format = fmt.parse(&mut mss)?;
 
@@ -140,26 +176,38 @@ impl<'s> WavReader<'s> {
 
                     // Record the bounds of the data chunk.
                     let data_start_pos = mss.pos();
-                    let data_end_pos = data.len.map(|len| data_start_pos + u64::from(len));
+
+                    // Per EBU Tech 3306, ds64 values only replace the corresponding 32-bit
+                    // field when that field is set to -1 (0xFFFFFFFF). DataChunk.len is None
+                    // when the 32-bit value was 0xFFFFFFFF.
+                    let data_len = match data.len {
+                        Some(len) => Some(u64::from(len)),
+                        None => rf64_sizes.data_size,
+                    };
+
+                    let data_end_pos = data_len.and_then(|len| data_start_pos.checked_add(len));
 
                     // Create the track.
                     let mut track = Track::new(0);
 
                     track.with_codec_params(CodecParameters::Audio(codec_params));
 
-                    let Some(packet_info) = packet_info
-                    else {
+                    let Some(packet_info) = packet_info else {
                         return decode_error("wav: missing format chunk");
                     };
 
-                    // Append Fact chunk fields to track.
-                    if let Some(fact) = &fact {
-                        append_fact_params(&mut track, fact);
+                    // Append Data chunk fields to track (sets num_frames from data length).
+                    if let Some(data_len) = data_len {
+                        append_data_params(&mut track, data_len, &packet_info);
                     }
 
-                    // Append Data chunk fields to track.
-                    if let Some(data_len) = data.len {
-                        append_data_params(&mut track, u64::from(data_len), &packet_info);
+                    // For RF64 files, prefer the sample count from ds64 over the computed
+                    // value. For standard WAV, prefer fact chunk over computed value.
+                    // Applied after append_data_params so the authoritative value wins.
+                    if let Some(sample_count) = rf64_sizes.sample_count {
+                        track.with_num_frames(sample_count);
+                    } else if let Some(fact) = &fact {
+                        append_fact_params(&mut track, fact);
                     }
 
                     // Instantiate the reader.
@@ -180,13 +228,15 @@ impl<'s> WavReader<'s> {
 
 impl Scoreable for WavReader<'_> {
     fn score(mut src: ScopedStream<&mut MediaSourceStream<'_>>) -> Result<Score> {
-        // Perform simple scoring by testing that the RIFF stream marker and RIFF form are both
-        // valid for WAVE.
-        let riff_marker = src.read_quad_bytes()?;
+        // Perform simple scoring by testing that the RIFF/RF64 stream marker and RIFF form are
+        // both valid for WAVE.
+        let marker = src.read_quad_bytes()?;
         src.ignore_bytes(4)?;
         let riff_form = src.read_quad_bytes()?;
 
-        if riff_marker != WAVE_STREAM_MARKER || riff_form != WAVE_RIFF_FORM {
+        let is_valid_marker = marker == WAVE_STREAM_MARKER || marker == RF64_STREAM_MARKER;
+
+        if !is_valid_marker || riff_form != WAVE_RIFF_FORM {
             return Ok(Score::Unsupported);
         }
 
@@ -210,6 +260,13 @@ impl ProbeableFormat<'_> for WavReader<'_> {
                 &["wav", "wave"],
                 &["audio/vnd.wave", "audio/x-wav", "audio/wav", "audio/wave"],
                 &[b"RIFF"]
+            ),
+            // RF64 extended WAVE format (64-bit extension for files > 4GB)
+            support_format!(
+                WAVE_FORMAT_INFO,
+                &["wav", "wave", "rf64"],
+                &["audio/vnd.wave", "audio/x-wav", "audio/wav", "audio/wave"],
+                &[b"RF64"]
             ),
         ]
     }
@@ -320,5 +377,202 @@ impl FormatReader for WavReader<'_> {
         Self: 's,
     {
         self.reader
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use symphonia_core::io::ReadOnlySource;
+
+    /// Creates a minimal valid RF64 file in memory.
+    fn create_rf64_test_file(data_size: u64, sample_count: u64, pcm_data: &[u8]) -> Vec<u8> {
+        let mut file = Vec::new();
+
+        // RF64 header
+        file.extend_from_slice(b"RF64");
+        file.extend_from_slice(&0xFFFFFFFFu32.to_le_bytes()); // placeholder size
+        file.extend_from_slice(b"WAVE");
+
+        // ds64 chunk (28 bytes)
+        file.extend_from_slice(b"ds64");
+        file.extend_from_slice(&28u32.to_le_bytes()); // chunk size
+        let riff_size: u64 = 4 + 8 + 28 + 8 + 16 + 8 + data_size; // WAVE + ds64 + fmt + data
+        file.extend_from_slice(&riff_size.to_le_bytes()); // riffSize64
+        file.extend_from_slice(&data_size.to_le_bytes()); // dataSize64
+        file.extend_from_slice(&sample_count.to_le_bytes()); // sampleCount64
+        file.extend_from_slice(&0u32.to_le_bytes()); // tableLength
+
+        // fmt chunk (16 bytes, PCM format)
+        file.extend_from_slice(b"fmt ");
+        file.extend_from_slice(&16u32.to_le_bytes());
+        file.extend_from_slice(&1u16.to_le_bytes()); // format = PCM
+        file.extend_from_slice(&1u16.to_le_bytes()); // channels = 1
+        file.extend_from_slice(&44100u32.to_le_bytes()); // sample rate
+        file.extend_from_slice(&88200u32.to_le_bytes()); // byte rate
+        file.extend_from_slice(&2u16.to_le_bytes()); // block align
+        file.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+
+        // data chunk
+        file.extend_from_slice(b"data");
+        let chunk_size = if data_size > u32::MAX as u64 { 0xFFFFFFFF } else { data_size as u32 };
+        file.extend_from_slice(&chunk_size.to_le_bytes());
+        file.extend_from_slice(pcm_data);
+
+        file
+    }
+
+    /// Creates a minimal valid standard WAV file in memory.
+    fn create_wav_test_file(pcm_data: &[u8]) -> Vec<u8> {
+        let mut file = Vec::new();
+        let data_len = pcm_data.len() as u32;
+
+        // RIFF header
+        file.extend_from_slice(b"RIFF");
+        let total_size = 4 + 8 + 16 + 8 + data_len; // WAVE + fmt chunk + data chunk
+        file.extend_from_slice(&total_size.to_le_bytes());
+        file.extend_from_slice(b"WAVE");
+
+        // fmt chunk
+        file.extend_from_slice(b"fmt ");
+        file.extend_from_slice(&16u32.to_le_bytes());
+        file.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        file.extend_from_slice(&1u16.to_le_bytes()); // mono
+        file.extend_from_slice(&44100u32.to_le_bytes()); // sample rate
+        file.extend_from_slice(&88200u32.to_le_bytes()); // byte rate
+        file.extend_from_slice(&2u16.to_le_bytes()); // block align
+        file.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+
+        // data chunk
+        file.extend_from_slice(b"data");
+        file.extend_from_slice(&data_len.to_le_bytes());
+        file.extend_from_slice(pcm_data);
+
+        file
+    }
+
+    #[test]
+    fn test_rf64_small_file() {
+        let pcm_data = vec![0u8; 1000]; // 500 samples at 16-bit mono
+        let rf64_file = create_rf64_test_file(1000, 500, &pcm_data);
+
+        let source = ReadOnlySource::new(Cursor::new(rf64_file));
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+
+        assert_eq!(reader.tracks.len(), 1);
+        assert_eq!(reader.tracks[0].num_frames, Some(500));
+    }
+
+    #[test]
+    fn test_rf64_large_data_size() {
+        let pcm_data = vec![0u8; 100];
+        let large_data_size: u64 = 5_000_000_000; // 5GB
+        let sample_count = large_data_size / 2; // 16-bit samples
+        let rf64_file = create_rf64_test_file(large_data_size, sample_count, &pcm_data);
+
+        let source = ReadOnlySource::new(Cursor::new(rf64_file));
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+
+        assert_eq!(reader.tracks.len(), 1);
+        assert_eq!(reader.tracks[0].num_frames, Some(sample_count));
+        // data_end_pos should use 64-bit size
+        let data_end = reader.data_end_pos.unwrap();
+        assert_eq!(data_end - reader.data_start_pos, large_data_size);
+    }
+
+    #[test]
+    fn test_standard_wav_unchanged() {
+        let pcm_data = vec![0u8; 100];
+        let wav_file = create_wav_test_file(&pcm_data);
+
+        let source = ReadOnlySource::new(Cursor::new(wav_file));
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+
+        assert_eq!(reader.tracks.len(), 1);
+        let data_end = reader.data_end_pos.unwrap();
+        assert_eq!(data_end - reader.data_start_pos, 100);
+    }
+
+    #[test]
+    fn test_rf64_missing_ds64_uses_fallback() {
+        // RF64 file without ds64 chunk should still work using 32-bit sizes.
+        let mut file = Vec::new();
+
+        file.extend_from_slice(b"RF64");
+        let total_size = 4 + 8 + 16 + 8 + 100;
+        file.extend_from_slice(&(total_size as u32).to_le_bytes());
+        file.extend_from_slice(b"WAVE");
+
+        // fmt chunk
+        file.extend_from_slice(b"fmt ");
+        file.extend_from_slice(&16u32.to_le_bytes());
+        file.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        file.extend_from_slice(&1u16.to_le_bytes()); // mono
+        file.extend_from_slice(&44100u32.to_le_bytes());
+        file.extend_from_slice(&88200u32.to_le_bytes());
+        file.extend_from_slice(&2u16.to_le_bytes());
+        file.extend_from_slice(&16u16.to_le_bytes());
+
+        // data chunk
+        file.extend_from_slice(b"data");
+        file.extend_from_slice(&100u32.to_le_bytes());
+        file.extend_from_slice(&vec![0u8; 100]);
+
+        let source = ReadOnlySource::new(Cursor::new(file));
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+        let data_end = reader.data_end_pos.unwrap();
+        assert_eq!(data_end - reader.data_start_pos, 100);
+    }
+
+    #[test]
+    fn test_ds64_ignored_in_standard_wav() {
+        // Standard RIFF/WAV with a ds64 chunk should ignore it.
+        let mut file = Vec::new();
+
+        file.extend_from_slice(b"RIFF");
+        let total_size = 4 + 8 + 28 + 8 + 16 + 8 + 100; // includes ds64
+        file.extend_from_slice(&(total_size as u32).to_le_bytes());
+        file.extend_from_slice(b"WAVE");
+
+        // ds64 chunk (should be ignored in standard WAV)
+        file.extend_from_slice(b"ds64");
+        file.extend_from_slice(&28u32.to_le_bytes());
+        file.extend_from_slice(&999999999u64.to_le_bytes()); // fake riff size
+        file.extend_from_slice(&888888888u64.to_le_bytes()); // fake data size (should NOT be used)
+        file.extend_from_slice(&777777777u64.to_le_bytes()); // fake sample count
+        file.extend_from_slice(&0u32.to_le_bytes());
+
+        // fmt chunk
+        file.extend_from_slice(b"fmt ");
+        file.extend_from_slice(&16u32.to_le_bytes());
+        file.extend_from_slice(&1u16.to_le_bytes());
+        file.extend_from_slice(&1u16.to_le_bytes());
+        file.extend_from_slice(&44100u32.to_le_bytes());
+        file.extend_from_slice(&88200u32.to_le_bytes());
+        file.extend_from_slice(&2u16.to_le_bytes());
+        file.extend_from_slice(&16u16.to_le_bytes());
+
+        // data chunk
+        file.extend_from_slice(b"data");
+        file.extend_from_slice(&100u32.to_le_bytes());
+        file.extend_from_slice(&vec![0u8; 100]);
+
+        let source = ReadOnlySource::new(Cursor::new(file));
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+        let reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+
+        // Should use 32-bit size from data chunk, NOT 64-bit from ds64
+        let data_end = reader.data_end_pos.unwrap();
+        assert_eq!(data_end - reader.data_start_pos, 100);
     }
 }


### PR DESCRIPTION
## Summary

Adds RF64/BW64 format support to the WAV demuxer, enabling playback of audio files exceeding the 4GB RIFF size limit.

- **DS64 chunk parser** — parses 64-bit sizes (riff_size, data_size, sample_count) and table entries per EBU Tech 3306
- **RF64 detection** — recognizes `RF64` stream marker alongside standard `RIFF`
- **64-bit size handling** — uses ds64 values only when the 32-bit sentinel (`0xFFFFFFFF`) is present, per spec
- **Probe/scoring** — adds RF64 probe descriptor and accepts RF64 marker in format scoring
- **Overflow safety** — validated ds64 table bounds, checked arithmetic for data position calculations
- **Tests** — ds64 parsing unit tests + RF64 integration tests (small files, >4GB metadata, fallback, ds64-in-standard-WAV ignored, malformed table rejection)

### EBU Tech 3306 compliance

- DS64 values only override 32-bit fields when those fields are set to `-1` (sentinel)
- DS64 sample_count takes precedence over fact chunk and computed value for RF64 files
- Table entry count validated against declared chunk size

## Context

Fresh rewrite of #425 for `dev-0.6` as requested. The original PR targeted `master` but a mechanical rebase failed due to significant API changes in dev-0.6 (lifetimes on `WavReader`, `FormatInfo`/`MetadataInfo` constants, `Track` construction, `DataChunk.len` as `Option<u32>`, etc).

## Test plan

- [x] `cargo check -p symphonia-format-riff` (all platforms)
- [x] `cargo test -p symphonia-format-riff` (11/11 pass)
- [x] `cargo clippy -p symphonia-format-riff` (clean)

**Note:** Rustfmt CI may fail due to pre-existing formatting issues in `aiff/mod.rs` and `fix_wave_channel_mask` on the `dev-0.6` branch — unrelated to this change.