### PR TITLE
fix(ogg): reset current page after probing start/end

### DIFF
--- a/symphonia-format-ogg/src/demuxer.rs
+++ b/symphonia-format-ogg/src/demuxer.rs
@@ -379,7 +379,12 @@ impl<'s> OggReader<'s> {
         }
 
         // Probe the logical streams for their start and end pages.
-        physical::probe_stream_start(&mut self.reader, &mut self.pages, &mut streams);
+        physical::probe_stream_start(
+            &mut self.reader,
+            &mut self.pages,
+            &mut streams,
+            byte_range_start,
+        )?;
 
         let mut byte_range_end = Default::default();
 


### PR DESCRIPTION
After calling `probe_stream_start`/`probe_stream_end`, the stream was not always being reset exactly to its previous state. The reader position was being reset, but the `probe_` methods call `next_page`, so the current page was changed and not set back to the previous value. This caused some pages to be skipped when calling `next_packet`.

It's necessary to seek back to `byte_range_start` rather than `original_pos` since we need to seek back one page before the initial position prior to calling calling `next_page`.

This was found when testing [this chained opus file](https://github.com/user-attachments/files/25353864/chained_opus.zip) that contains only one packet per stream. Without this change, all packets are skipped (I only have an Opus version, not a Vorbis one, sorry).


