### PR TITLE
core: Replace buffer capacity panics with Result<()>

### DIFF
--- a/symphonia-play/src/output.rs
+++ b/symphonia-play/src/output.rs
@@ -104,6 +104,11 @@ mod pulseaudio {
             }
 
             // Interleave samples from the audio buffer into the sample buffer.
+            let n_samples = decoded.frames() * decoded.spec().channels.count();
+            if self.sample_buf.capacity() < n_samples {
+                error!("audio output write error: sample buffer capacity exceeded");
+                return Err(AudioOutputError::StreamClosedError);
+            }
             self.sample_buf.copy_interleaved_ref(decoded);
 
             // Write interleaved samples to PulseAudio.
@@ -327,6 +332,11 @@ mod cpal {
             }
             else {
                 // Resampling is not required. Interleave the sample for cpal using a sample buffer.
+                let n_samples = decoded.frames() * decoded.spec().channels.count();
+                if self.sample_buf.capacity() < n_samples {
+                    error!("audio output write error: sample buffer capacity exceeded");
+                    return Err(AudioOutputError::StreamClosedError);
+                }
                 self.sample_buf.copy_interleaved_ref(decoded);
 
                 self.sample_buf.samples()

--- a/symphonia/examples/basic-interleaved.rs
+++ b/symphonia/examples/basic-interleaved.rs
@@ -85,6 +85,10 @@ fn main() {
 
                 // Copy the decoded audio buffer into the sample buffer in an interleaved format.
                 if let Some(buf) = &mut sample_buf {
+                    if buf.capacity() < audio_buf.frames() * audio_buf.spec().channels.count() {
+                        // The audio buffer is too large for the sample buffer.
+                        break;
+                    }
                     buf.copy_interleaved_ref(audio_buf);
 
                     // The samples may now be access via the `samples()` function.


### PR DESCRIPTION
Refactors `AudioBuffer::convert`, `SampleBuffer::copy_*`, `RawSampleBuffer::copy_*`, and `Signal::render*` methods to return `Result<()>` instead of panicking when the destination buffer capacity is insufficient.

This improves robustness against malformed inputs or incorrect usage, ensuring that the library returns a handleable error (`decode_error("capacity will be exceeded")`) rather than crashing the application.

This change required updating call sites across the workspace to propagate or handle the new errors.

Tests have been added to `symphonia-core` to verify the new behavior.

We have previously worked on landing fuzzing fixes in this area for dev-0.6. Since a v0.5 maintainence release is imminent, I think these changes will help make that release more robust.