### PR TITLE
vorbis: Clamp Floor1 values to prevent out-of-bounds access

### DIFF
--- a/symphonia-codec-vorbis/src/floor.rs
+++ b/symphonia-codec-vorbis/src/floor.rs
@@ -632,12 +632,12 @@ impl Floor1 {
         let mut hx = 0;
         let mut hy = 0;
         let mut lx = 0;
-        let mut ly = floor_final_y0 * multiplier;
+        let mut ly = (floor_final_y0 * multiplier).clamp(0, 255);
 
         // Iterate in sort-order.
         for i in self.setup.floor1_x_list_sort_order[1..].iter().map(|i| *i as usize) {
             if self.floor_step2_flag[i] {
-                hy = self.floor_final_y[i] * multiplier;
+                hy = (self.floor_final_y[i] * multiplier).clamp(0, 255);
                 hx = self.setup.floor1_x_list[i];
 
                 render_line(lx, ly, hx, hy, n as usize, floor);
@@ -783,6 +783,10 @@ fn render_point(x0: u32, y0: i32, x1: u32, y1: i32, x: u32) -> i32 {
 
 #[inline(always)]
 fn render_line(x0: u32, y0: i32, x1: u32, y1: i32, n: usize, v: &mut [f32]) {
+    if x0 as usize >= n {
+        return;
+    }
+
     let dy = y1 - y0;
     let adx = (x1 - x0) as i32;
 
@@ -800,6 +804,10 @@ fn render_line(x0: u32, y0: i32, x1: u32, y1: i32, n: usize, v: &mut [f32]) {
 
     let x_begin = x0 as usize + 1;
     let x_end = min(n, x1 as usize);
+
+    if x_begin > x_end {
+        return;
+    }
 
     for v in v[x_begin..x_end].iter_mut() {
         err += ady;


### PR DESCRIPTION
This patch addresses a crash in the Vorbis decoder by implementing bounds checking and value clamping in the Floor1 implementation. 

Instead of clamping values inside the inner loop of `render_line` (which impacts performance), this change applies clamping once per line segment in `synthesis_step2`. This guarantees the Y values will map correctly to the 256-element inverse dB table.

Additionally, the `render_line` function was hardened with early exits and explicit checks to ensure that both the starting and ending X coordinates remain within the current block size. These changes prevent malformed or malicious bitstream data from triggering out-of-bounds Rust panics and subsequent application aborts.

Issue discovered by fuzzing in Chrome, see https://crbug.com/498549512.