### PR TITLE
mp4: add audio profile detection

### DIFF
--- a/symphonia-common/src/mpeg/audio/mod.rs
+++ b/symphonia-common/src/mpeg/audio/mod.rs
@@ -6,6 +6,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use symphonia_core::audio::{Channels, layouts};
+use symphonia_core::codecs::CodecProfile;
+use symphonia_core::codecs::audio::well_known::profiles::*;
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::{BitReaderLtr, FiniteBitStream, ReadBitsLtr};
 
@@ -225,7 +227,7 @@ pub struct AudioSpecificConfig {
 }
 
 impl AudioSpecificConfig {
-    /// Read the audio specific configuration from the provided buffer.
+    /// Read the audio specific configuration from the provided buffer. ISO14496-3-2009
     pub fn read(buf: &[u8]) -> Result<AudioSpecificConfig> {
         let mut bs = BitReaderLtr::new(buf);
 
@@ -242,6 +244,10 @@ impl AudioSpecificConfig {
         asc.channels = Self::read_channel_config(&mut bs)?;
 
         if (asc.object_type == AudioObjectType::Sbr) || (asc.object_type == AudioObjectType::Ps) {
+            asc.sbr_present = true;
+            if asc.object_type == AudioObjectType::Ps {
+                asc.ps_present = true;
+            }
             let ext_srate = Self::read_sampling_frequency(&mut bs)?;
             asc.object_type = Self::read_audio_object_type(&mut bs)?;
 
@@ -455,5 +461,25 @@ impl AudioSpecificConfig {
             }
         };
         Ok(channels)
+    }
+}
+
+pub fn get_audio_codec_profile(asc: &AudioSpecificConfig) -> Option<CodecProfile> {
+    match asc.object_type {
+        AudioObjectType::Main => Some(CODEC_PROFILE_AAC_MAIN),
+        AudioObjectType::Ssr => Some(CODEC_PROFILE_AAC_SSR),
+        AudioObjectType::Ltp => Some(CODEC_PROFILE_AAC_LTP),
+        AudioObjectType::Lc => {
+            if asc.ps_present {
+                Some(CODEC_PROFILE_AAC_HE_V2)
+            }
+            else if asc.sbr_present {
+                Some(CODEC_PROFILE_AAC_HE)
+            }
+            else {
+                Some(CODEC_PROFILE_AAC_LC)
+            }
+        }
+        _ => None,
     }
 }

--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -77,6 +77,7 @@ impl EsdsAtom {
         if let Some(ds_config) = &self.es_desc.dec_config.dec_specific_info {
             // Try to read the audio specific configuration and populate the audio sample entry.
             if let Ok(asc) = AudioSpecificConfig::read(&ds_config.extra_data) {
+                entry.profile = get_audio_codec_profile(&asc);
                 entry.channels = asc.channels;
             }
 

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -144,6 +144,7 @@ pub struct AudioSampleEntry {
     pub sample_size: u16,
     pub sample_rate: f64,
     pub codec_id: AudioCodecId,
+    pub profile: Option<CodecProfile>,
     pub bits_per_sample: Option<u32>,
     pub bits_per_coded_sample: Option<u32>,
     pub frames_per_packet: Option<u64>,
@@ -156,6 +157,7 @@ impl AudioSampleEntry {
     pub(crate) fn make_codec_params(&self) -> AudioCodecParameters {
         AudioCodecParameters {
             codec: self.codec_id,
+            profile: self.profile,
             sample_rate: Some(self.sample_rate as u32),
             bits_per_sample: self.bits_per_sample,
             bits_per_coded_sample: self.bits_per_coded_sample,


### PR DESCRIPTION
HE-AAC and HE-AAC v2 are not detected correctly, and Symphonia attempts to decode them as LC.

Fix SBR and PS detection according to ISO/IEC 14496-3 (section 1.6.2.1, AudioSpecificConfig).

Expose the profile for MP4.

This will provide a clearer error explanation for #480 instead of attempting to decode it.