### PR TITLE
mkv: set track duration

### DIFF
--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -14,7 +14,7 @@ use symphonia_core::formats::prelude::*;
 use symphonia_core::formats::probe::{ProbeFormatData, ProbeableFormat, Score, Scoreable};
 use symphonia_core::formats::well_known::FORMAT_ID_MKV;
 use symphonia_core::io::*;
-use symphonia_core::meta::{Metadata, MetadataLog};
+use symphonia_core::meta::{Metadata, MetadataLog, RawValue};
 use symphonia_core::support_format;
 use symphonia_core::units::TimeBase;
 
@@ -28,6 +28,8 @@ use crate::segment::{
     AttachmentsElement, BlockGroupElement, ChaptersElement, CuesElement, EbmlHeaderElement,
     InfoElement, SeekHeadElement, TagsElement, TargetTagsMap, TracksElement,
 };
+use crate::sub_fields::TAG_DURATION;
+use crate::tags::TargetName;
 
 const MKV_FORMAT_INFO: FormatInfo =
     FormatInfo { format: FORMAT_ID_MKV, short_name: "matroska", long_name: "Matroska / WebM" };
@@ -273,6 +275,7 @@ impl<'s> MkvReader<'s> {
 
         let mut tracks = Vec::new();
         let mut track_states = HashMap::new();
+        let duration_tag_raw_key = TargetName::Movie.as_str().to_string() + "@" + TAG_DURATION;
 
         for track in segment_tracks.tracks {
             // Create the track state.
@@ -297,6 +300,24 @@ impl<'s> MkvReader<'s> {
 
             if let Some(duration) = info.duration {
                 tr.with_num_frames(duration as u64);
+
+                let duration_from_tag = metadata
+                    .metadata()
+                    .current()
+                    .and_then(|rev| {
+                        rev.per_track.iter().find(|meta| meta.track_id == track.uid.get())
+                    })
+                    .and_then(|meta| {
+                        meta.metadata.tags.iter().find(|tag| tag.raw.key == duration_tag_raw_key)
+                    })
+                    .and_then(|tag| match &tag.raw.value {
+                        RawValue::String(s) => parse_mkv_duration(s),
+                        _ => None,
+                    });
+
+                tr.with_duration(
+                    duration_from_tag.unwrap_or_else(|| Duration::from(duration as u64)),
+                );
             }
 
             if let Some(lang_bcp47) = &track.lang_bcp47 {
@@ -654,4 +675,27 @@ impl From<EbmlError> for Error {
         };
         Error::DecodeError(msg)
     }
+}
+
+fn parse_mkv_duration(s: &str) -> Option<Duration> {
+    let (hms, frac) = s.split_once('.')?;
+    if frac.len() != 9 {
+        return None;
+    }
+
+    let mut it = hms.split(':');
+
+    let (h, m, s) = (
+        it.next()?.parse::<u32>().ok()?,
+        it.next()?.parse::<u32>().ok()?,
+        it.next()?.parse::<u32>().ok()?,
+    );
+
+    if it.next().is_some() || m >= 60 || s >= 60 {
+        return None;
+    }
+
+    let nanos = frac.parse::<u32>().ok()?;
+
+    Some(Duration::from(h * 3_600_000 + m * 60_000 + s * 1_000 + nanos / 1_000_000))
 }

--- a/symphonia-format-mkv/src/lib.rs
+++ b/symphonia-format-mkv/src/lib.rs
@@ -30,6 +30,7 @@ pub mod sub_fields {
     //! For the exact meaning of these fields, and the format of their values, please consult the
     //! official Matroska specification.
 
+    pub const TAG_DURATION: &str = "DURATION";
     pub const TAG_LANGUAGE: &str = "LANGUAGE";
     pub const TAG_LANGUAGE_BCP47: &str = "LANGUAGE_BCP47";
 

--- a/symphonia-format-mkv/src/tags.rs
+++ b/symphonia-format-mkv/src/tags.rs
@@ -29,6 +29,38 @@ pub struct TagContext {
     pub target: Option<Target>,
 }
 
+pub enum TargetName {
+    Collection,
+    Volume,
+    Edition,
+    Movie,
+    Album,
+    Part,
+    Chapter,
+    Track,
+    Scene,
+    Subtrack,
+    Shot,
+}
+
+impl TargetName {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            TargetName::Collection => "COLLECTION",
+            TargetName::Volume => "VOLUME",
+            TargetName::Edition => "EDITION",
+            TargetName::Movie => "MOVIE",
+            TargetName::Album => "ALBUM",
+            TargetName::Part => "PART",
+            TargetName::Chapter => "CHAPTER",
+            TargetName::Track => "TRACK",
+            TargetName::Scene => "SCENE",
+            TargetName::Subtrack => "SUBTRACK",
+            TargetName::Shot => "SHOT",
+        }
+    }
+}
+
 pub fn make_raw_tags(tag: SimpleTagElement, ctx: &TagContext, out: &mut Vec<RawTag>) {
     // The nested sub-tags of the following tags are flattened into multiple raw tags:
     //
@@ -327,17 +359,17 @@ pub fn map_std_tag(raw: &RawTag, lower_ctx: &TagContext) -> Option<StandardTag> 
 /// assumes target names that are logical for a movie.
 fn default_target_name(target_value: u64, is_video: bool) -> Option<&'static str> {
     let name = match target_value {
-        70 => "COLLECTION",
-        60 if is_video => "VOLUME",
-        60 => "EDITION",
-        50 if is_video => "MOVIE",
-        50 => "ALBUM",
-        40 => "PART",
-        30 if is_video => "CHAPTER",
-        30 => "TRACK",
-        20 if is_video => "SCENE",
-        20 => "SUBTRACK",
-        10 if is_video => "SHOT",
+        70 => TargetName::Collection.as_str(),
+        60 if is_video => TargetName::Volume.as_str(),
+        60 => TargetName::Edition.as_str(),
+        50 if is_video => TargetName::Movie.as_str(),
+        50 => TargetName::Album.as_str(),
+        40 => TargetName::Part.as_str(),
+        30 if is_video => TargetName::Chapter.as_str(),
+        30 => TargetName::Track.as_str(),
+        20 if is_video => TargetName::Scene.as_str(),
+        20 => TargetName::Subtrack.as_str(),
+        10 if is_video => TargetName::Shot.as_str(),
         _ => return None,
     };
     Some(name)


### PR DESCRIPTION
Sets duration for mkv. Improved version for mkv vs the simple one from #332.
Takes duration from tag if it exists.

Feel free to change the implementation and add DURATION into some standard tag, if you want.