### PR TITLE
Introduce PacketRef for zero-copy packet passing

### DIFF
--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -259,7 +259,7 @@ impl AudioDecoder for FlacDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-bundle-flac/src/decoder.rs
+++ b/symphonia-bundle-flac/src/decoder.rs
@@ -20,7 +20,7 @@ use symphonia_core::codecs::audio::{AudioDecoder, FinalizeResult, VerificationCh
 use symphonia_core::codecs::registry::{RegisterableAudioDecoder, SupportedAudioCodec};
 use symphonia_core::errors::{Error, Result, decode_error, unsupported_error};
 use symphonia_core::io::{BitReaderLtr, BufReader, ReadBitsLtr};
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 use symphonia_core::support_audio_codec;
 use symphonia_core::util::bits::sign_extend_leq32_to_i32;
 
@@ -135,7 +135,7 @@ impl FlacDecoder {
         })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         let mut reader = packet.as_buf_reader();
 
         // Synchronize to a frame and get the synchronization code.
@@ -259,7 +259,7 @@ impl AudioDecoder for FlacDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-bundle-mp3/src/decoder.rs
+++ b/symphonia-bundle-mp3/src/decoder.rs
@@ -13,7 +13,7 @@ use symphonia_core::codecs::audio::{
 use symphonia_core::codecs::registry::{RegisterableAudioDecoder, SupportedAudioCodec};
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::FiniteStream;
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 use symphonia_core::support_audio_codec;
 
 #[cfg(feature = "mp1")]
@@ -82,7 +82,7 @@ impl MpaDecoder {
         Ok(MpaDecoder { opts: *opts, params: params.clone(), state, buf: Default::default() })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         let mut reader = packet.as_buf_reader();
 
         let header = header::read_frame_header(&mut reader)?;
@@ -150,7 +150,7 @@ impl AudioDecoder for MpaDecoder {
         self.state = State::new(self.params.codec);
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-bundle-mp3/src/decoder.rs
+++ b/symphonia-bundle-mp3/src/decoder.rs
@@ -150,7 +150,7 @@ impl AudioDecoder for MpaDecoder {
         self.state = State::new(self.params.codec);
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-aac/src/aac/mod.rs
+++ b/symphonia-codec-aac/src/aac/mod.rs
@@ -261,7 +261,7 @@ impl AudioDecoder for AacDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-aac/src/aac/mod.rs
+++ b/symphonia-codec-aac/src/aac/mod.rs
@@ -21,7 +21,7 @@ use symphonia_core::codecs::audio::{AudioDecoder, FinalizeResult};
 use symphonia_core::codecs::registry::{RegisterableAudioDecoder, SupportedAudioCodec};
 use symphonia_core::errors::{Result, unsupported_error};
 use symphonia_core::io::{BitReaderLtr, FiniteBitStream, ReadBitsLtr};
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 use symphonia_core::{codec_profile, support_audio_codec};
 
 use symphonia_common::mpeg::audio::{AudioObjectType, AudioSpecificConfig};
@@ -228,7 +228,7 @@ impl AacDecoder {
     //     }
     // }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         // Clear the audio output buffer.
         self.buf.clear();
         self.buf.render_uninit(None);
@@ -261,7 +261,7 @@ impl AudioDecoder for AacDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-adpcm/src/lib.rs
+++ b/symphonia-codec-adpcm/src/lib.rs
@@ -173,7 +173,7 @@ impl AudioDecoder for AdpcmDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-adpcm/src/lib.rs
+++ b/symphonia-codec-adpcm/src/lib.rs
@@ -28,7 +28,7 @@ use symphonia_core::codecs::audio::{AudioCodecId, AudioCodecParameters, AudioDec
 use symphonia_core::codecs::audio::{AudioDecoder, FinalizeResult};
 use symphonia_core::errors::{Result, unsupported_error};
 use symphonia_core::io::ReadBytes;
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 
 mod codec_ima_qt;
 mod codec_ima_wav;
@@ -119,7 +119,7 @@ impl AdpcmDecoder {
         })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         let mut stream = packet.as_buf_reader();
 
         let frames_per_block = self.params.frames_per_block.unwrap() as usize;
@@ -173,7 +173,7 @@ impl AudioDecoder for AdpcmDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-alac/src/lib.rs
+++ b/symphonia-codec-alac/src/lib.rs
@@ -29,7 +29,7 @@ use symphonia_core::codecs::audio::{AudioDecoder, FinalizeResult};
 use symphonia_core::codecs::registry::{RegisterableAudioDecoder, SupportedAudioCodec};
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::{BitReaderLtr, BufReader, FiniteStream, ReadBitsLtr, ReadBytes};
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 use symphonia_core::support_audio_codec;
 
 /// Supported ALAC version.
@@ -457,7 +457,7 @@ impl AlacDecoder {
         Ok(AlacDecoder { params: params.clone(), tail_bits: vec![0; max_tail_values], buf, config })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         let mut bs = BitReaderLtr::new(packet.buf());
 
         let channel_map = map_channels(&self.config.channels);
@@ -577,7 +577,7 @@ impl AudioDecoder for AlacDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-alac/src/lib.rs
+++ b/symphonia-codec-alac/src/lib.rs
@@ -577,7 +577,7 @@ impl AudioDecoder for AlacDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-pcm/src/lib.rs
+++ b/symphonia-codec-pcm/src/lib.rs
@@ -425,7 +425,7 @@ impl AudioDecoder for PcmDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-pcm/src/lib.rs
+++ b/symphonia-codec-pcm/src/lib.rs
@@ -45,7 +45,7 @@ use symphonia_core::audio::sample::SampleFormat;
 use symphonia_core::codecs::audio::well_known::{CODEC_ID_PCM_ALAW, CODEC_ID_PCM_MULAW};
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::ReadBytes;
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 
 macro_rules! read_pcm_signed {
     ($buf:expr, $fmt:tt, $read:expr, $width:expr, $shift:expr) => {
@@ -315,7 +315,7 @@ impl PcmDecoder {
         Ok(PcmDecoder { params: params.clone(), shift, bytes_per_coded_frame, buf })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         // Calculate the number of complete audio frames per-packet.
         let num_frames = packet.buf().len() / self.bytes_per_coded_frame;
 
@@ -425,7 +425,7 @@ impl AudioDecoder for PcmDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-vorbis/src/lib.rs
+++ b/symphonia-codec-vorbis/src/lib.rs
@@ -347,7 +347,7 @@ impl AudioDecoder for VorbisDecoder {
         &self.params
     }
 
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-codec-vorbis/src/lib.rs
+++ b/symphonia-codec-vorbis/src/lib.rs
@@ -27,7 +27,7 @@ use symphonia_core::codecs::registry::{RegisterableAudioDecoder, SupportedAudioC
 use symphonia_core::dsp::mdct::Imdct;
 use symphonia_core::errors::{Result, decode_error, unsupported_error};
 use symphonia_core::io::{BitReaderRtl, BufReader, FiniteBitStream, ReadBitsRtl, ReadBytes};
-use symphonia_core::packet::Packet;
+use symphonia_core::packet::PacketRef;
 use symphonia_core::support_audio_codec;
 
 use symphonia_common::xiph::audio::vorbis::*;
@@ -143,7 +143,7 @@ impl VorbisDecoder {
         })
     }
 
-    fn decode_inner(&mut self, packet: &Packet) -> Result<()> {
+    fn decode_inner(&mut self, packet: &PacketRef<'_>) -> Result<()> {
         let mut bs = BitReaderRtl::new(packet.buf());
 
         // Section 4.3.1 - Packet Type, Mode, and Window Decode
@@ -347,7 +347,7 @@ impl AudioDecoder for VorbisDecoder {
         &self.params
     }
 
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>> {
         if let Err(e) = self.decode_inner(packet) {
             self.buf.clear();
             Err(e)

--- a/symphonia-core/src/codecs/audio.rs
+++ b/symphonia-core/src/codecs/audio.rs
@@ -14,7 +14,7 @@ use crate::audio::{Channels, GenericAudioBufferRef};
 use crate::codecs::{CodecInfo, CodecProfile};
 use crate::common::FourCc;
 use crate::errors::Result;
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketRef};
 
 /// An `AudioCodecId` is a unique identifier used to identify a specific audio codec.
 ///
@@ -276,7 +276,15 @@ pub trait AudioDecoder: Send + Sync {
     /// the decoded audio buffer to change. All other errors are unrecoverable.
     ///
     /// Implementors of decoders *must* `clear` the internal audio buffer if an error occurs.
-    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>>;
+    fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
+        self.decode_ext(&packet.as_packet_ref())
+    }
+
+    /// Decodes a `PacketRef` of audio data and returns a generic (untyped) audio buffer reference
+    /// containing the decoded audio.
+    ///
+    /// This method is identical to `decode` but takes a `PacketRef` for zero-copy packet passing.
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>>;
 
     /// Optionally, obtain post-decode information such as the verification status.
     fn finalize(&mut self) -> FinalizeResult;

--- a/symphonia-core/src/codecs/audio.rs
+++ b/symphonia-core/src/codecs/audio.rs
@@ -277,14 +277,14 @@ pub trait AudioDecoder: Send + Sync {
     ///
     /// Implementors of decoders *must* `clear` the internal audio buffer if an error occurs.
     fn decode(&mut self, packet: &Packet) -> Result<GenericAudioBufferRef<'_>> {
-        self.decode_ext(&packet.as_packet_ref())
+        self.decode_ref(&packet.as_packet_ref())
     }
 
     /// Decodes a `PacketRef` of audio data and returns a generic (untyped) audio buffer reference
     /// containing the decoded audio.
     ///
     /// This method is identical to `decode` but takes a `PacketRef` for zero-copy packet passing.
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>>;
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericAudioBufferRef<'_>>;
 
     /// Optionally, obtain post-decode information such as the verification status.
     fn finalize(&mut self) -> FinalizeResult;

--- a/symphonia-core/src/codecs/subtitle.rs
+++ b/symphonia-core/src/codecs/subtitle.rs
@@ -15,7 +15,7 @@ use crate::common::FourCc;
 #[cfg(feature = "exp-subtitle-codecs")]
 use crate::errors::Result;
 #[cfg(feature = "exp-subtitle-codecs")]
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketRef};
 #[cfg(feature = "exp-subtitle-codecs")]
 use crate::subtitle::GenericSubtitleBufferRef;
 
@@ -123,7 +123,15 @@ pub trait SubtitleDecoder: Send + Sync {
     /// discarded. Decoding may be continued with the next packet.
     ///
     /// Implementors of decoders *must* `clear` the last decoded subtitle if an error occurs.
-    fn decode(&mut self, packet: &Packet) -> Result<GenericSubtitleBufferRef<'_>>;
+    fn decode(&mut self, packet: &Packet) -> Result<GenericSubtitleBufferRef<'_>> {
+        self.decode_ext(&packet.as_packet_ref())
+    }
+
+    /// Decodes a `PacketRef` of subtitle data and returns a generic (untyped) subtitle buffer reference
+    /// containing the decoded subtitles.
+    ///
+    /// This method is identical to `decode` but takes a `PacketRef` for zero-copy packet passing.
+    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericSubtitleBufferRef<'_>>;
 
     /// Allows read access to the internal audio buffer.
     ///

--- a/symphonia-core/src/codecs/subtitle.rs
+++ b/symphonia-core/src/codecs/subtitle.rs
@@ -124,14 +124,14 @@ pub trait SubtitleDecoder: Send + Sync {
     ///
     /// Implementors of decoders *must* `clear` the last decoded subtitle if an error occurs.
     fn decode(&mut self, packet: &Packet) -> Result<GenericSubtitleBufferRef<'_>> {
-        self.decode_ext(&packet.as_packet_ref())
+        self.decode_ref(&packet.as_packet_ref())
     }
 
     /// Decodes a `PacketRef` of subtitle data and returns a generic (untyped) subtitle buffer reference
     /// containing the decoded subtitles.
     ///
     /// This method is identical to `decode` but takes a `PacketRef` for zero-copy packet passing.
-    fn decode_ext(&mut self, packet: &PacketRef<'_>) -> Result<GenericSubtitleBufferRef<'_>>;
+    fn decode_ref(&mut self, packet: &PacketRef<'_>) -> Result<GenericSubtitleBufferRef<'_>>;
 
     /// Allows read access to the internal audio buffer.
     ///

--- a/symphonia-core/src/packet.rs
+++ b/symphonia-core/src/packet.rs
@@ -147,6 +147,130 @@ impl Packet {
     pub fn as_buf_reader(&self) -> BufReader<'_> {
         BufReader::new(&self.data)
     }
+
+    /// Get a `PacketRef` borrowing this packet.
+    #[inline]
+    pub fn as_packet_ref(&self) -> PacketRef<'_> {
+        PacketRef::new(self.track_id, self.pts, self.dur, &self.data)
+            .with_dts(self.dts)
+            .with_trim_start(self.trim_start)
+            .with_trim_end(self.trim_end)
+    }
+}
+
+/// A borrowed reference to a packet.
+///
+/// `PacketRef` is the zero-copy equivalent of `Packet`. It is particularly useful when
+/// packet data is already residing in an application-managed fixed buffer or when data is
+/// passed in from external environments like C/C++ via FFI. This allows decoders to process
+/// the data directly without forcing a heap allocation and deep copy.
+#[derive(Clone, Copy)]
+pub struct PacketRef<'a> {
+    track_id: u32,
+    pub pts: Timestamp,
+    pub dts: Timestamp,
+    pub dur: Duration,
+    pub trim_start: Duration,
+    pub trim_end: Duration,
+    pub data: &'a [u8],
+}
+
+impl<'a> PacketRef<'a> {
+    /// Create a new untrimmed `PacketRef`.
+    ///
+    /// The `data` slice can be constructed directly from a fixed-size buffer, or from
+    /// raw FFI pointers (e.g., a C++ `std::vector` payload) using `std::slice::from_raw_parts`.
+    pub fn new(track_id: u32, pts: Timestamp, dur: Duration, data: &'a [u8]) -> Self {
+        PacketRef {
+            track_id,
+            pts,
+            dts: pts,
+            dur,
+            trim_start: Duration::ZERO,
+            trim_end: Duration::ZERO,
+            data,
+        }
+    }
+
+    /// Provide the decode timestamp (DTS).
+    pub fn with_dts(mut self, dts: Timestamp) -> Self {
+        self.dts = dts;
+        self
+    }
+
+    /// Provide the trim start duration.
+    pub fn with_trim_start(mut self, trim_start: Duration) -> Self {
+        self.trim_start = trim_start;
+        self
+    }
+
+    /// Provide the trim end duration.
+    pub fn with_trim_end(mut self, trim_end: Duration) -> Self {
+        self.trim_end = trim_end;
+        self
+    }
+
+    /// The track identifier of the track this packet belongs to.
+    #[inline]
+    pub const fn track_id(&self) -> u32 {
+        self.track_id
+    }
+
+    /// Get the presentation timestamp (PTS) of the packet in `TimeBase` units.
+    #[inline]
+    pub const fn pts(&self) -> Timestamp {
+        self.pts
+    }
+
+    /// Get the decode timestamp (DTS) of the packet in `TimeBase` units.
+    #[inline]
+    pub const fn dts(&self) -> Timestamp {
+        self.dts
+    }
+
+    /// Get the duration of all *valid* frames in the packet in `TimeBase` units.
+    #[inline]
+    pub const fn dur(&self) -> Duration {
+        self.dur
+    }
+
+    /// Get the duration of all *decoded* frames in the packet in `TimeBase` units.
+    #[inline]
+    pub const fn block_dur(&self) -> Duration {
+        self.dur.saturating_add(self.trim_start).saturating_add(self.trim_end)
+    }
+
+    /// Get the duration of *decoded* frames that should be trimmed from the start of the decoded
+    /// buffer to remove encoder delay.
+    #[inline]
+    pub const fn trim_start(&self) -> Duration {
+        self.trim_start
+    }
+
+    /// Get the duration of *decoded* frames that should be trimmed from the end of the decoded
+    /// buffer to remove encoder padding.
+    #[inline]
+    pub const fn trim_end(&self) -> Duration {
+        self.trim_end
+    }
+
+    /// Get an immutable slice to the packet data buffer.
+    #[inline]
+    pub const fn buf(&self) -> &[u8] {
+        self.data
+    }
+
+    /// Get a `BufReader` to read the packet data buffer sequentially.
+    #[inline]
+    pub fn as_buf_reader(&self) -> BufReader<'_> {
+        BufReader::new(self.data)
+    }
+}
+
+impl<'a> From<&'a Packet> for PacketRef<'a> {
+    fn from(packet: &'a Packet) -> Self {
+        packet.as_packet_ref()
+    }
 }
 
 mod builder {
@@ -311,3 +435,48 @@ mod builder {
 }
 
 pub use builder::PacketBuilder;
+
+#[cfg(test)]
+mod tests {
+    use super::{Packet, PacketRef};
+    use crate::units::{Duration, Timestamp};
+
+    #[test]
+    fn verify_packet_ref_creation() {
+        let data: &[u8] = &[1, 2, 3, 4];
+        let pkt_ref = PacketRef::new(1, Timestamp::new(100), Duration::from(50_u64), data)
+            .with_dts(Timestamp::new(90))
+            .with_trim_start(Duration::from(10_u64))
+            .with_trim_end(Duration::from(5_u64));
+
+        assert_eq!(pkt_ref.track_id(), 1);
+        assert_eq!(pkt_ref.pts(), Timestamp::new(100));
+        assert_eq!(pkt_ref.dts(), Timestamp::new(90));
+        assert_eq!(pkt_ref.dur(), Duration::from(50_u64));
+        assert_eq!(pkt_ref.trim_start(), Duration::from(10_u64));
+        assert_eq!(pkt_ref.trim_end(), Duration::from(5_u64));
+        assert_eq!(pkt_ref.buf(), &[1, 2, 3, 4]);
+
+        // block_dur = dur + trim_start + trim_end = 50 + 10 + 5 = 65
+        assert_eq!(pkt_ref.block_dur(), Duration::from(65_u64));
+    }
+
+    #[test]
+    fn verify_packet_to_packet_ref() {
+        let data = vec![5, 6, 7, 8];
+        let mut pkt = Packet::new(2, Timestamp::new(200), Duration::from(100_u64), data);
+        pkt.dts = Timestamp::new(190);
+        pkt.trim_start = Duration::from(20_u64);
+        pkt.trim_end = Duration::from(10_u64);
+
+        let pkt_ref = pkt.as_packet_ref();
+
+        assert_eq!(pkt_ref.track_id(), 2);
+        assert_eq!(pkt_ref.pts(), Timestamp::new(200));
+        assert_eq!(pkt_ref.dts(), Timestamp::new(190));
+        assert_eq!(pkt_ref.dur(), Duration::from(100_u64));
+        assert_eq!(pkt_ref.trim_start(), Duration::from(20_u64));
+        assert_eq!(pkt_ref.trim_end(), Duration::from(10_u64));
+        assert_eq!(pkt_ref.buf(), &[5, 6, 7, 8]);
+    }
+}


### PR DESCRIPTION
Resolves issue #166.

This change introduces a new `PacketRef` structure that acts as a borrowed version of `Packet`, allowing for zero-copy decoding when application data already resides in a fixed buffer or when data is passed from an external FFI environment (e.g., C++ std::vector) as a slice.

- Implemented `PacketRef` struct with slice borrowing
- Updated AudioDecoder and SubtitleDecoder traits to accept PacketRef
- Adapted all decoders (AAC, ALAC, ADPCM, FLAC, MP3, PCM, Vorbis)
- Updated tests, examples, and fuzzers
- Added PacketRef specific unit tests in packet.rs

I verified these changes programmatically using a custom GlobalAlloc implementation which tracked memory allocations. The test proved that constructing a PacketRef from a pre-allocated slice eliminated the heap allocation and data copying that Packet previously required.