### PR TITLE
Fix some crashes

### DIFF
--- a/symphonia-codec-adpcm/src/codec_ima_wav.rs
+++ b/symphonia-codec-adpcm/src/codec_ima_wav.rs
@@ -44,6 +44,9 @@ pub(crate) fn decode_stereo<B: ReadBytes>(
     buffers: [&mut [i32]; 2],
     frames_per_block: usize,
 ) -> Result<()> {
+    if frames_per_block == 0 || (frames_per_block - 1) % 8 != 0 {
+        return decode_error("adpcm (ima): frames_per_block - 1 must be a multiple of 8");
+    }
     let data_bytes_per_channel = frames_per_block - 1;
     let mut status = [read_preamble(stream)?, read_preamble(stream)?];
     buffers[0][0] = from_i16_shift!(status[0].predictor);

--- a/symphonia-format-isomp4/src/atoms/ftyp.rs
+++ b/symphonia-format-isomp4/src/atoms/ftyp.rs
@@ -33,7 +33,8 @@ impl Atom for FtypAtom {
         }
 
         // Major
-        let major = FourCc::new(it.read_quad_bytes()?);
+        let major = FourCc::try_new(it.read_quad_bytes()?)
+            .ok_or(Error::DecodeError("isomp4 (ftyp): major brand contains non-ASCII bytes"))?;
 
         // Minor
         let minor = it.read_quad_bytes()?;
@@ -47,7 +48,9 @@ impl Atom for FtypAtom {
 
         for _ in 0..n_brands {
             let brand = it.read_quad_bytes()?;
-            compatible.push(FourCc::new(brand));
+            if let Some(fourcc) = FourCc::try_new(brand) {
+                compatible.push(fourcc);
+            }
         }
 
         Ok(FtypAtom { major, minor, compatible })

--- a/symphonia-format-isomp4/src/atoms/stsc.rs
+++ b/symphonia-format-isomp4/src/atoms/stsc.rs
@@ -64,8 +64,14 @@ impl Atom for StscAtom {
         let mut entries = Vec::with_capacity(MAX_TABLE_INITIAL_CAPACITY.min(entry_count as usize));
 
         for _ in 0..entry_count {
+            let first_chunk_raw = it.read_u32()?;
+
+            if first_chunk_raw == 0 {
+                return decode_error("isomp4 (stsc): first_chunk must be >= 1");
+            }
+
             entries.push(StscEntry {
-                first_chunk: it.read_u32()? - 1,
+                first_chunk: first_chunk_raw - 1,
                 first_sample: 0,
                 samples_per_chunk: it.read_u32()?,
                 sample_desc_index: it.read_u32()?,
@@ -87,8 +93,14 @@ impl Atom for StscAtom {
 
                 let n = entries[i + 1].first_chunk - entries[i].first_chunk;
 
-                entries[i + 1].first_sample =
-                    entries[i].first_sample + (n * entries[i].samples_per_chunk);
+                let Some(chunk_samples) = n
+                    .checked_mul(entries[i].samples_per_chunk)
+                    .and_then(|v| entries[i].first_sample.checked_add(v))
+                else {
+                    return decode_error("isomp4 (stsc): sample count overflow");
+                };
+
+                entries[i + 1].first_sample = chunk_samples;
             }
 
             // Validate that samples per chunk is > 0. Could the entry be ignored?

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -530,6 +530,10 @@ impl Atom for VisualSampleEntry {
             let mut name = [0u8; 31];
             it.read_buf_exact(&mut name)?;
 
+            if len > 31 {
+                return decode_error("isomp4 (stsd): compressor name length exceeds 31 bytes");
+            }
+
             match str::from_utf8(&name[..len]) {
                 Ok(name) => Some(name.to_string()),
                 _ => None,

--- a/symphonia-format-isomp4/src/atoms/stts.rs
+++ b/symphonia-format-isomp4/src/atoms/stts.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::atoms::limits::*;
-use crate::atoms::{Atom, AtomHeader, AtomIterator, ReadAtom, Result};
+use crate::atoms::{Atom, AtomHeader, AtomIterator, ReadAtom, Result, decode_error};
 
 #[derive(Debug)]
 pub struct SampleDurationEntry {
@@ -82,13 +82,18 @@ impl Atom for SttsAtom {
         // available memory.
         let mut entries = Vec::with_capacity(MAX_TABLE_INITIAL_CAPACITY.min(entry_count as usize));
 
-        let mut total_duration = 0;
+        let mut total_duration: u64 = 0;
 
         for _ in 0..entry_count {
             let sample_count = it.read_u32()?;
             let sample_delta = it.read_u32()?;
 
-            total_duration += u64::from(sample_count) * u64::from(sample_delta);
+            let Some(next_duration) =
+                total_duration.checked_add(u64::from(sample_count) * u64::from(sample_delta))
+            else {
+                return decode_error("isomp4 (stts): total duration overflow");
+            };
+            total_duration = next_duration;
 
             entries.push(SampleDurationEntry { sample_count, sample_delta });
         }


### PR DESCRIPTION
This fixes crashes, that I had with symphonia:
```
thread 'main' (84782) panicked at /home/runner/.cargo/git/checkouts/symphonia-6dce4e040d3ff5a1/3bc744e/symphonia-format-isomp4/src/atoms/stsc.rs:69:30:
attempt to subtract with overflow
```
```
thread 'main' (31762) panicked at /home/runner/.cargo/git/checkouts/symphonia-6dce4e040d3ff5a1/3bc744e/symphonia-core/src/common.rs:24:9:
only ASCII characters are allowed in a FourCc
```
```
thread 'main' (105840) panicked at /home/runner/.cargo/git/checkouts/symphonia-6dce4e040d3ff5a1/3bc744e/symphonia-format-isomp4/src/atoms/stts.rs:92:13:
attempt to add with overflow
```
```
memory allocation of 34225520648 bytes failed
```
```
thread 'main' (1406603) panicked at /home/rafal/test/Symphonia/symphonia-format-isomp4/src/atoms/stsc.rs:98:25:
attempt to multiply with overflow
```
```
thread 'main' (1468410) panicked at /home/rafal/test/Symphonia/symphonia-format-isomp4/src/atoms/stsd.rs:533:39:
range end index 128 out of range for slice of length 31
```
```
thread 'main' (1496014) panicked at /home/rafal/test/Symphonia/symphonia-codec-adpcm/src/codec_ima_wav.rs:58:9:
index out of bounds: the len is 760 but the index is 760
```