### PR TITLE
Parse channel count from opus atom

### DIFF
--- a/symphonia-common/src/xiph/audio/mod.rs
+++ b/symphonia-common/src/xiph/audio/mod.rs
@@ -13,4 +13,5 @@
 #![allow(clippy::manual_range_contains)]
 
 pub mod flac;
+pub mod opus;
 pub mod vorbis;

--- a/symphonia-common/src/xiph/audio/opus/mod.rs
+++ b/symphonia-common/src/xiph/audio/opus/mod.rs
@@ -1,0 +1,118 @@
+use symphonia_core::{
+    audio::{Channels, Position},
+    errors::Result,
+    io::ReadBytes,
+};
+
+const OPUS_MAGIC_SIGNATURE: &[u8] = b"OpusHead";
+
+#[derive(Debug, Default)]
+pub struct StreamInfo {
+    pub version: u8,
+    pub channels: Channels,
+    pub original_sample_rate: u32,
+    pub gain: i16,
+    pub pre_skip: u16,
+}
+
+impl StreamInfo {
+    pub fn read<B: ReadBytes>(reader: &mut B, max_version: u8) -> Result<Option<Self>> {
+        // The first 8 bytes are the magic signature ASCII bytes.
+        let mut magic = [0; 8];
+        reader.read_buf_exact(&mut magic)?;
+
+        if magic != *OPUS_MAGIC_SIGNATURE {
+            return Ok(None);
+        }
+
+        // The next byte is the encapsulation version. The max version is specified by the caller since it
+        // depends on the container format used.
+        let version = reader.read_byte()?;
+        if version > max_version {
+            return Ok(None);
+        }
+
+        // The next byte is the number of channels and must not be 0.
+        let channel_count = reader.read_byte()?;
+
+        if channel_count == 0 {
+            return Ok(None);
+        }
+
+        // The next 16-bit integer is the pre-skip padding (# of samples at 48kHz to subtract from the
+        // OGG granule position to obtain the PCM sample position).
+        let pre_skip = reader.read_u16()?;
+
+        // The next 32-bit integer is the sample rate of the original audio.
+        let original_sample_rate = reader.read_u32()?;
+
+        // Next, the 16-bit gain value.
+        let gain = reader.read_i16()?;
+
+        // The next byte indicates the channel mapping. Most of these values are reserved.
+        let channel_mapping = reader.read_byte()?;
+
+        let positions = match channel_mapping {
+            // RTP Mapping
+            0 if channel_count == 1 => Position::FRONT_LEFT,
+            0 if channel_count == 2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
+            // Vorbis Mapping
+            1 => match channel_count {
+                1 => Position::FRONT_LEFT,
+                2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
+                3 => Position::FRONT_LEFT | Position::FRONT_CENTER | Position::FRONT_RIGHT,
+                4 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                }
+                5 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                }
+                6 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                        | Position::LFE1
+                }
+                7 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::SIDE_LEFT
+                        | Position::SIDE_RIGHT
+                        | Position::REAR_CENTER
+                        | Position::LFE1
+                }
+                8 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::SIDE_LEFT
+                        | Position::SIDE_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                        | Position::LFE1
+                }
+                _ => return Ok(None),
+            },
+            // Reserved, and should NOT be supported for playback.
+            _ => return Ok(None),
+        };
+
+        Ok(Some(Self {
+            version,
+            channels: Channels::Positioned(positions),
+            gain,
+            original_sample_rate,
+            pre_skip,
+        }))
+    }
+}

--- a/symphonia-format-isomp4/src/atoms/opus.rs
+++ b/symphonia-format-isomp4/src/atoms/opus.rs
@@ -71,6 +71,7 @@ impl Atom for OpusAtom {
 impl OpusAtom {
     pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) -> Result<()> {
         entry.codec_id = CODEC_ID_OPUS;
+        entry.extra_data = Some(self.extra_data.clone());
 
         let mut reader = BufReader::new(&self.extra_data[OPUS_MAGIC_LEN..]);
 

--- a/symphonia-format-isomp4/src/atoms/opus.rs
+++ b/symphonia-format-isomp4/src/atoms/opus.rs
@@ -5,10 +5,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use symphonia_core::audio::{Channels, Position};
+use std::convert::identity;
+
+use symphonia_common::xiph::audio::opus;
 use symphonia_core::codecs::audio::well_known::CODEC_ID_OPUS;
 use symphonia_core::errors::Error;
-use symphonia_core::io::{BufReader, ReadBytes};
+use symphonia_core::io::BufReader;
 
 use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{
@@ -28,7 +30,6 @@ pub struct OpusAtom {
 
 impl Atom for OpusAtom {
     fn read<R: ReadAtom>(reader: &mut AtomIterator<R>, header: &AtomHeader) -> Result<Self> {
-
         const MIN_OPUS_EXTRA_DATA_SIZE: usize = OPUS_MAGIC_LEN + 11;
         const MAX_OPUS_EXTRA_DATA_SIZE: usize = MIN_OPUS_EXTRA_DATA_SIZE + 257;
 
@@ -69,87 +70,15 @@ impl Atom for OpusAtom {
 }
 
 impl OpusAtom {
-    pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) -> Result<()> {
-        entry.codec_id = CODEC_ID_OPUS;
-        entry.extra_data = Some(self.extra_data.clone());
+    pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) {
+        let mut reader = BufReader::new(&self.extra_data);
 
-        let mut reader = BufReader::new(&self.extra_data[OPUS_MAGIC_LEN..]);
-
-        // Version is already checked
-        let _version = reader.read_u8()?;
-
-        let channel_count = reader.read_u8()?;
-                
-        if channel_count == 0 {
-            return Ok(());
+        if let Some(stream_info) = opus::StreamInfo::read(&mut reader, 0).ok().and_then(identity) {
+            entry.channels = Some(stream_info.channels);
+            entry.sample_rate = 48_000.0;
         }
 
-        let _pre_skip = reader.read_be_u16()?;
-
-        let _input_sample_rate = reader.read_be_u32()?;
-
-        let _output_gain = reader.read_be_i16()?;
-
-        let channel_mapping = reader.read_u8()?;
-
-        let positions = match channel_mapping {
-            // RTP Mapping
-            0 if channel_count == 1 => Position::FRONT_LEFT,
-            0 if channel_count == 2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
-            // Vorbis Mapping
-            1 => match channel_count {
-                1 => Position::FRONT_LEFT,
-                2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
-                3 => Position::FRONT_LEFT | Position::FRONT_CENTER | Position::FRONT_RIGHT,
-                4 => {
-                    Position::FRONT_LEFT
-                        | Position::FRONT_RIGHT
-                        | Position::REAR_LEFT
-                        | Position::REAR_RIGHT
-                }
-                5 => {
-                    Position::FRONT_LEFT
-                        | Position::FRONT_CENTER
-                        | Position::FRONT_RIGHT
-                        | Position::REAR_LEFT
-                        | Position::REAR_RIGHT
-                }
-                6 => {
-                    Position::FRONT_LEFT
-                        | Position::FRONT_CENTER
-                        | Position::FRONT_RIGHT
-                        | Position::REAR_LEFT
-                        | Position::REAR_RIGHT
-                        | Position::LFE1
-                }
-                7 => {
-                    Position::FRONT_LEFT
-                        | Position::FRONT_CENTER
-                        | Position::FRONT_RIGHT
-                        | Position::SIDE_LEFT
-                        | Position::SIDE_RIGHT
-                        | Position::REAR_CENTER
-                        | Position::LFE1
-                }
-                8 => {
-                    Position::FRONT_LEFT
-                        | Position::FRONT_CENTER
-                        | Position::FRONT_RIGHT
-                        | Position::SIDE_LEFT
-                        | Position::SIDE_RIGHT
-                        | Position::REAR_LEFT
-                        | Position::REAR_RIGHT
-                        | Position::LFE1
-                }
-                _ => return Ok(()),
-            },
-            // Reserved, and should NOT be supported for playback.
-            _ => return Ok(()),
-        };
-
-        entry.channels = Some(Channels::Positioned(positions));
-        entry.sample_rate = 48_000.0;
-
-        Ok(())
+        entry.codec_id = CODEC_ID_OPUS;
+        entry.extra_data = Some(self.extra_data);
     }
 }

--- a/symphonia-format-isomp4/src/atoms/opus.rs
+++ b/symphonia-format-isomp4/src/atoms/opus.rs
@@ -5,6 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use symphonia_core::audio::{Channels, Position};
 use symphonia_core::codecs::audio::well_known::CODEC_ID_OPUS;
 use symphonia_core::errors::Error;
 
@@ -17,8 +18,10 @@ use crate::atoms::{
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct OpusAtom {
-    /// Opus extra data (identification header).
-    extra_data: Box<[u8]>,
+    /// Audio channels
+    channels: Channels,
+    /// Pre skip
+    pre_skip: u16,
 }
 
 impl Atom for OpusAtom {
@@ -28,9 +31,6 @@ impl Atom for OpusAtom {
 
         const MIN_OPUS_EXTRA_DATA_SIZE: usize = OPUS_MAGIC_LEN + 11;
         const MAX_OPUS_EXTRA_DATA_SIZE: usize = MIN_OPUS_EXTRA_DATA_SIZE + 257;
-
-        // Offset of the Opus version number in the extra data.
-        const OPUS_EXTRADATA_VERSION_OFFSET: usize = OPUS_MAGIC_LEN;
 
         // The dops atom contains an Opus identification header excluding the OpusHead magic
         // signature. Therefore, the atom data length should be atleast as long as the shortest
@@ -48,26 +48,90 @@ impl Atom for OpusAtom {
             return decode_error("isomp4 (opus): opus identification header too large");
         }
 
-        let mut extra_data = vec![0; OPUS_MAGIC_LEN + data_len].into_boxed_slice();
-
-        // The Opus magic is excluded in the atom, but the extra data must start with it.
-        extra_data[..OPUS_MAGIC_LEN].copy_from_slice(OPUS_MAGIC);
-
-        // Read the extra data from the atom.
-        reader.read_buf_exact(&mut extra_data[OPUS_MAGIC_LEN..])?;
+        let version = reader.read_byte()?;
 
         // Verify the version number is 0.
-        if extra_data[OPUS_EXTRADATA_VERSION_OFFSET] != 0 {
+        if version != 0 {
             return unsupported_error("isomp4 (opus): unsupported opus version");
         }
 
-        Ok(OpusAtom { extra_data })
+        let channel_count = reader.read_byte()?;
+
+        if channel_count == 0 {
+            return decode_error("isomp4 (opus): Invalid channel count");
+        }
+
+        let pre_skip = u16::from_be_bytes(reader.read_double_bytes()?);
+
+        let _input_sample_rate = u32::from_be_bytes(reader.read_quad_bytes()?);
+
+        let _output_gain = i16::from_be_bytes(reader.read_double_bytes()?);
+
+        let channel_mapping = reader.read_byte()?;
+
+        let positions = match channel_mapping {
+            // RTP Mapping
+            0 if channel_count == 1 => Position::FRONT_LEFT,
+            0 if channel_count == 2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
+            // Vorbis Mapping
+            1 => match channel_count {
+                1 => Position::FRONT_LEFT,
+                2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
+                3 => Position::FRONT_LEFT | Position::FRONT_CENTER | Position::FRONT_RIGHT,
+                4 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                }
+                5 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                }
+                6 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                        | Position::LFE1
+                }
+                7 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::SIDE_LEFT
+                        | Position::SIDE_RIGHT
+                        | Position::REAR_CENTER
+                        | Position::LFE1
+                }
+                8 => {
+                    Position::FRONT_LEFT
+                        | Position::FRONT_CENTER
+                        | Position::FRONT_RIGHT
+                        | Position::SIDE_LEFT
+                        | Position::SIDE_RIGHT
+                        | Position::REAR_LEFT
+                        | Position::REAR_RIGHT
+                        | Position::LFE1
+                }
+                _ => return decode_error("isomp4 (opus): Invalid channel mapping"),
+            },
+            // Reserved, and should NOT be supported for playback.
+            _ => return decode_error("isomp4 (opus): Invalid channel mapping"),
+        };
+
+        Ok(OpusAtom { channels: Channels::Positioned(positions), pre_skip })
     }
 }
 
 impl OpusAtom {
     pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) {
         entry.codec_id = CODEC_ID_OPUS;
-        entry.extra_data = Some(self.extra_data);
+        entry.channels = Some(self.channels);
+        entry.sample_rate = 48_000.0;
     }
 }

--- a/symphonia-format-isomp4/src/atoms/opus.rs
+++ b/symphonia-format-isomp4/src/atoms/opus.rs
@@ -8,29 +8,32 @@
 use symphonia_core::audio::{Channels, Position};
 use symphonia_core::codecs::audio::well_known::CODEC_ID_OPUS;
 use symphonia_core::errors::Error;
+use symphonia_core::io::{BufReader, ReadBytes};
 
 use crate::atoms::stsd::AudioSampleEntry;
 use crate::atoms::{
     Atom, AtomHeader, AtomIterator, ReadAtom, Result, decode_error, unsupported_error,
 };
 
+const OPUS_MAGIC: &[u8] = b"OpusHead";
+const OPUS_MAGIC_LEN: usize = OPUS_MAGIC.len();
+
 /// Opus atom.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct OpusAtom {
-    /// Audio channels
-    channels: Channels,
-    /// Pre skip
-    pre_skip: u16,
+    /// Opus extra data (identification header).
+    extra_data: Box<[u8]>,
 }
 
 impl Atom for OpusAtom {
     fn read<R: ReadAtom>(reader: &mut AtomIterator<R>, header: &AtomHeader) -> Result<Self> {
-        const OPUS_MAGIC: &[u8] = b"OpusHead";
-        const OPUS_MAGIC_LEN: usize = OPUS_MAGIC.len();
 
         const MIN_OPUS_EXTRA_DATA_SIZE: usize = OPUS_MAGIC_LEN + 11;
         const MAX_OPUS_EXTRA_DATA_SIZE: usize = MIN_OPUS_EXTRA_DATA_SIZE + 257;
+
+        // Offset of the Opus version number in the extra data.
+        const OPUS_EXTRADATA_VERSION_OFFSET: usize = OPUS_MAGIC_LEN;
 
         // The dops atom contains an Opus identification header excluding the OpusHead magic
         // signature. Therefore, the atom data length should be atleast as long as the shortest
@@ -48,26 +51,45 @@ impl Atom for OpusAtom {
             return decode_error("isomp4 (opus): opus identification header too large");
         }
 
-        let version = reader.read_byte()?;
+        let mut extra_data = vec![0; OPUS_MAGIC_LEN + data_len].into_boxed_slice();
+
+        // The Opus magic is excluded in the atom, but the extra data must start with it.
+        extra_data[..OPUS_MAGIC_LEN].copy_from_slice(OPUS_MAGIC);
+
+        // Read the extra data from the atom.
+        reader.read_buf_exact(&mut extra_data[OPUS_MAGIC_LEN..])?;
 
         // Verify the version number is 0.
-        if version != 0 {
+        if extra_data[OPUS_EXTRADATA_VERSION_OFFSET] != 0 {
             return unsupported_error("isomp4 (opus): unsupported opus version");
         }
 
-        let channel_count = reader.read_byte()?;
+        Ok(OpusAtom { extra_data })
+    }
+}
 
+impl OpusAtom {
+    pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) -> Result<()> {
+        entry.codec_id = CODEC_ID_OPUS;
+
+        let mut reader = BufReader::new(&self.extra_data[OPUS_MAGIC_LEN..]);
+
+        // Version is already checked
+        let _version = reader.read_u8()?;
+
+        let channel_count = reader.read_u8()?;
+                
         if channel_count == 0 {
-            return decode_error("isomp4 (opus): Invalid channel count");
+            return Ok(());
         }
 
-        let pre_skip = u16::from_be_bytes(reader.read_double_bytes()?);
+        let _pre_skip = reader.read_be_u16()?;
 
-        let _input_sample_rate = u32::from_be_bytes(reader.read_quad_bytes()?);
+        let _input_sample_rate = reader.read_be_u32()?;
 
-        let _output_gain = i16::from_be_bytes(reader.read_double_bytes()?);
+        let _output_gain = reader.read_be_i16()?;
 
-        let channel_mapping = reader.read_byte()?;
+        let channel_mapping = reader.read_u8()?;
 
         let positions = match channel_mapping {
             // RTP Mapping
@@ -118,20 +140,15 @@ impl Atom for OpusAtom {
                         | Position::REAR_RIGHT
                         | Position::LFE1
                 }
-                _ => return decode_error("isomp4 (opus): Invalid channel mapping"),
+                _ => return Ok(()),
             },
             // Reserved, and should NOT be supported for playback.
-            _ => return decode_error("isomp4 (opus): Invalid channel mapping"),
+            _ => return Ok(()),
         };
 
-        Ok(OpusAtom { channels: Channels::Positioned(positions), pre_skip })
-    }
-}
-
-impl OpusAtom {
-    pub fn fill_audio_sample_entry(self, entry: &mut AudioSampleEntry) {
-        entry.codec_id = CODEC_ID_OPUS;
-        entry.channels = Some(self.channels);
+        entry.channels = Some(Channels::Positioned(positions));
         entry.sample_rate = 48_000.0;
+
+        Ok(())
     }
 }

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -322,7 +322,7 @@ impl Atom for AudioSampleEntry {
                 }
                 AtomType::OpusDsConfig => {
                     let atom = it.read_atom::<OpusAtom>()?;
-                    atom.fill_audio_sample_entry(&mut entry)?;
+                    atom.fill_audio_sample_entry(&mut entry);
                 }
                 AtomType::AudioSampleEntryQtWave => {
                     // The QuickTime WAVE (aka. siDecompressionParam) atom may contain many

--- a/symphonia-format-isomp4/src/atoms/stsd.rs
+++ b/symphonia-format-isomp4/src/atoms/stsd.rs
@@ -322,7 +322,7 @@ impl Atom for AudioSampleEntry {
                 }
                 AtomType::OpusDsConfig => {
                     let atom = it.read_atom::<OpusAtom>()?;
-                    atom.fill_audio_sample_entry(&mut entry);
+                    atom.fill_audio_sample_entry(&mut entry)?;
                 }
                 AtomType::AudioSampleEntryQtWave => {
                     // The QuickTime WAVE (aka. siDecompressionParam) atom may contain many

--- a/symphonia-format-ogg/src/mappings/opus.rs
+++ b/symphonia-format-ogg/src/mappings/opus.rs
@@ -9,7 +9,7 @@ use crate::common::SideData;
 
 use super::{MapResult, Mapper, PacketParser};
 
-use symphonia_core::audio::{Channels, Position};
+use symphonia_common::xiph::audio::opus;
 use symphonia_core::codecs::CodecParameters;
 use symphonia_core::codecs::audio::AudioCodecParameters;
 use symphonia_core::codecs::audio::well_known::CODEC_ID_OPUS;
@@ -26,9 +26,6 @@ use log::warn;
 /// The minimum expected size of an Opus identification packet.
 const OGG_OPUS_MIN_IDENTIFICATION_PACKET_SIZE: usize = 19;
 
-/// The signature for an Opus identification packet.
-const OGG_OPUS_MAGIC_SIGNATURE: &[u8] = b"OpusHead";
-
 /// The signature for an Opus metadata packet.
 const OGG_OPUS_COMMENT_SIGNATURE: &[u8] = b"OpusTags";
 
@@ -43,94 +40,9 @@ pub fn detect(serial: u32, buf: &[u8]) -> Result<Option<Box<dyn Mapper>>> {
 
     let mut reader = BufReader::new(buf);
 
-    // The first 8 bytes are the magic signature ASCII bytes.
-    let mut magic = [0; 8];
-    reader.read_buf_exact(&mut magic)?;
-
-    if magic != *OGG_OPUS_MAGIC_SIGNATURE {
+    let Some(stream_info) = opus::StreamInfo::read(&mut reader, OGG_OPUS_MAPPING_VERSION_MAX)?
+    else {
         return Ok(None);
-    }
-
-    // The next byte is the OGG Opus encapsulation version. The version is split into two
-    // sub-fields: major and minor. These fields are stored in the upper and lower 4-bit,
-    // respectively.
-    if reader.read_byte()? > OGG_OPUS_MAPPING_VERSION_MAX {
-        return Ok(None);
-    }
-
-    // The next byte is the number of channels and must not be 0.
-    let channel_count = reader.read_byte()?;
-
-    if channel_count == 0 {
-        return Ok(None);
-    }
-
-    // The next 16-bit integer is the pre-skip padding (# of samples at 48kHz to subtract from the
-    // OGG granule position to obtain the PCM sample position).
-    let pre_skip = reader.read_u16()?;
-
-    // The next 32-bit integer is the sample rate of the original audio.
-    let _ = reader.read_u32()?;
-
-    // Next, the 16-bit gain value.
-    let _ = reader.read_u16()?;
-
-    // The next byte indicates the channel mapping. Most of these values are reserved.
-    let channel_mapping = reader.read_byte()?;
-
-    let positions = match channel_mapping {
-        // RTP Mapping
-        0 if channel_count == 1 => Position::FRONT_LEFT,
-        0 if channel_count == 2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
-        // Vorbis Mapping
-        1 => match channel_count {
-            1 => Position::FRONT_LEFT,
-            2 => Position::FRONT_LEFT | Position::FRONT_RIGHT,
-            3 => Position::FRONT_LEFT | Position::FRONT_CENTER | Position::FRONT_RIGHT,
-            4 => {
-                Position::FRONT_LEFT
-                    | Position::FRONT_RIGHT
-                    | Position::REAR_LEFT
-                    | Position::REAR_RIGHT
-            }
-            5 => {
-                Position::FRONT_LEFT
-                    | Position::FRONT_CENTER
-                    | Position::FRONT_RIGHT
-                    | Position::REAR_LEFT
-                    | Position::REAR_RIGHT
-            }
-            6 => {
-                Position::FRONT_LEFT
-                    | Position::FRONT_CENTER
-                    | Position::FRONT_RIGHT
-                    | Position::REAR_LEFT
-                    | Position::REAR_RIGHT
-                    | Position::LFE1
-            }
-            7 => {
-                Position::FRONT_LEFT
-                    | Position::FRONT_CENTER
-                    | Position::FRONT_RIGHT
-                    | Position::SIDE_LEFT
-                    | Position::SIDE_RIGHT
-                    | Position::REAR_CENTER
-                    | Position::LFE1
-            }
-            8 => {
-                Position::FRONT_LEFT
-                    | Position::FRONT_CENTER
-                    | Position::FRONT_RIGHT
-                    | Position::SIDE_LEFT
-                    | Position::SIDE_RIGHT
-                    | Position::REAR_LEFT
-                    | Position::REAR_RIGHT
-                    | Position::LFE1
-            }
-            _ => return Ok(None),
-        },
-        // Reserved, and should NOT be supported for playback.
-        _ => return Ok(None),
     };
 
     // Populate the codec parameters with the information read from identification header.
@@ -139,13 +51,15 @@ pub fn detect(serial: u32, buf: &[u8]) -> Result<Option<Box<dyn Mapper>>> {
     codec_params
         .for_codec(CODEC_ID_OPUS)
         .with_sample_rate(48_000)
-        .with_channels(Channels::Positioned(positions))
+        .with_channels(stream_info.channels)
         .with_extra_data(Box::from(buf));
 
     // Create the track.
     let mut track = Track::new(serial);
 
-    track.with_codec_params(CodecParameters::Audio(codec_params)).with_delay(u32::from(pre_skip));
+    track
+        .with_codec_params(CodecParameters::Audio(codec_params))
+        .with_delay(u32::from(stream_info.pre_skip));
 
     // Instantiate the Opus mapper.
     let mapper = Box::new(OpusMapper { track, need_comment: true });


### PR DESCRIPTION
Implemented based on: [https://www.opus-codec.org/docs/opus_in_isobmff.html](https://www.opus-codec.org/docs/opus_in_isobmff.html)

Fixes #498