### PR TITLE
mp3 (layer3): accept main_data offset at buffer end for zero-length

### DIFF
--- a/symphonia-bundle-mp3/src/layer3/mod.rs
+++ b/symphonia-bundle-mp3/src/layer3/mod.rs
@@ -305,7 +305,8 @@ impl Layer3 {
                 let byte_index = part2_3_begin >> 3;
 
                 // Create a bit reader at the expected starting bit position.
-                let mut bs = if byte_index < main_data.len() {
+                // A zero byte silent channel can begin exactly at main_data.len().
+                let mut bs = if byte_index <= main_data.len() {
                     let mut bs = BitReaderLtr::new(&main_data[byte_index..]);
 
                     let bit_index = part2_3_begin & 0x7;


### PR DESCRIPTION
It's valid for MP3s to contain zero-byte-length channels and they can end up last in the buffer.