### PR TITLE
Fix out-of-bounds index panic in AAC section data decoding

### DIFF
--- a/symphonia-codec-aac/src/aac/ics/mod.rs
+++ b/symphonia-codec-aac/src/aac/ics/mod.rs
@@ -240,6 +240,8 @@ impl Ics {
             let mut l = 0;
 
             while k < self.info.max_sfb {
+                validate!(l < MAX_SFBS);
+
                 self.sect_cb[g][l] = bs.read_bits_leq32(4)? as u8;
                 self.sect_len[g][l] = 0;
 


### PR DESCRIPTION
Resolves an issue where a crafted stream can produce many zero-length sections, causing the section index `l` to exceed `MAX_SFBS` and panic when accessing `sect_cb` and `sect_len`.

Fixes #512.