### PR TITLE
Fix multiple OOM vulnerabilities related to missing size checks in metadata

### DIFF
--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -35,6 +35,15 @@ impl Atom for EsdsAtom {
 
         let mut descriptor = None;
 
+        // In practice, esds atoms are incredibly small, typically between 30 to 150 bytes in size.
+        // While the specification allows for much larger sizes, we can put a reasonable upper bound
+        // on the size of an esds atom to prevent malformed files from causing us to allocate large
+        // amounts of memory.
+        const MAX_ESDS_ATOM_SIZE: u64 = 4 * 1024;
+        if size > MAX_ESDS_ATOM_SIZE {
+            return decode_error("isomp4 (esds): atom size is greater than limit");
+        }
+
         if size > MIN_OBJECT_DESCRIPTOR_SIZE {
             // Read into buffer to be able to use a buffer reader.
             let buf = it.read_boxed_slice_exact(size as usize)?;

--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -36,9 +36,9 @@ impl Atom for EsdsAtom {
         let mut descriptor = None;
 
         // Elementary Stream Descriptors (esds) are exceptionally small (typically 30-150 bytes).
-        // We set a 4KiB limit to easily accommodate any valid esds while safely guarding against
+        // We set a generous limit to easily accommodate any valid esds while safely guarding against
         // huge size fields on malformed files.
-        const MAX_ESDS_ATOM_SIZE: u64 = 4 * 1024;
+        const MAX_ESDS_ATOM_SIZE: u64 = 8 * 1024;
         if size > MAX_ESDS_ATOM_SIZE {
             return decode_error("isomp4 (esds): atom size is greater than limit");
         }

--- a/symphonia-format-isomp4/src/atoms/esds.rs
+++ b/symphonia-format-isomp4/src/atoms/esds.rs
@@ -35,10 +35,9 @@ impl Atom for EsdsAtom {
 
         let mut descriptor = None;
 
-        // In practice, esds atoms are incredibly small, typically between 30 to 150 bytes in size.
-        // While the specification allows for much larger sizes, we can put a reasonable upper bound
-        // on the size of an esds atom to prevent malformed files from causing us to allocate large
-        // amounts of memory.
+        // Elementary Stream Descriptors (esds) are exceptionally small (typically 30-150 bytes).
+        // We set a 4KiB limit to easily accommodate any valid esds while safely guarding against
+        // huge size fields on malformed files.
         const MAX_ESDS_ATOM_SIZE: u64 = 4 * 1024;
         if size > MAX_ESDS_ATOM_SIZE {
             return decode_error("isomp4 (esds): atom size is greater than limit");

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -23,6 +23,11 @@ use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, ReadAtom, Result, d
 
 use log::{debug, warn};
 
+/// Maximum size of a metadata atom (e.g. cover art, namespace) to prevent OOM on malformed files.
+/// We use a generous 16MiB limit to handle large embedded art while preventing runaway allocations.
+#[allow(dead_code)]
+const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
+
 const ISOMP4_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_ISOMP4,
     short_name: "isomp4",

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -595,10 +595,13 @@ impl Atom for MetaTagDataAtom {
 
         // The data payload is the remainder of the atom.
         let data = {
-            // TODO: Apply the metadata limit.
             let size = it
                 .data_left()?
                 .ok_or(Error::DecodeError("isomp4 (data): expected atom size to be known"))?;
+
+            if size > 16 * 1024 * 1024 {
+                return decode_error("isomp4 (data): atom size exceeds 16MiB limit");
+            }
 
             it.read_boxed_slice_exact(size as usize)?
         };

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -24,9 +24,8 @@ use crate::atoms::{Atom, AtomHeader, AtomIterator, AtomType, ReadAtom, Result, d
 use log::{debug, warn};
 
 /// Maximum size of a metadata atom (e.g. cover art, namespace) to prevent OOM on malformed files.
-/// We use a generous 16MiB limit to handle large embedded art while preventing runaway allocations.
-#[allow(dead_code)]
-const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
+/// We use a generous limit to handle large embedded art while preventing runaway allocations.
+const MAX_METADATA_ATOM_SIZE: u64 = 32 * 1024 * 1024;
 
 const ISOMP4_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_ISOMP4,
@@ -603,8 +602,6 @@ impl Atom for MetaTagDataAtom {
             let size = it
                 .data_left()?
                 .ok_or(Error::DecodeError("isomp4 (data): expected atom size to be known"))?;
-
-            const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
             if size > MAX_METADATA_ATOM_SIZE {
                 return decode_error("isomp4 (data): atom size exceeds limit");
             }
@@ -630,8 +627,6 @@ impl Atom for MetaTagNamespaceAtom {
         let size = it
             .data_left()?
             .ok_or(Error::DecodeError("isomp4 (ilst): expected atom size to be known"))?;
-
-        const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
         if size > MAX_METADATA_ATOM_SIZE {
             return decode_error("isomp4 (ilst): atom size exceeds limit");
         }

--- a/symphonia-format-isomp4/src/atoms/ilst.rs
+++ b/symphonia-format-isomp4/src/atoms/ilst.rs
@@ -599,8 +599,9 @@ impl Atom for MetaTagDataAtom {
                 .data_left()?
                 .ok_or(Error::DecodeError("isomp4 (data): expected atom size to be known"))?;
 
-            if size > 16 * 1024 * 1024 {
-                return decode_error("isomp4 (data): atom size exceeds 16MiB limit");
+            const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
+            if size > MAX_METADATA_ATOM_SIZE {
+                return decode_error("isomp4 (data): atom size exceeds limit");
             }
 
             it.read_boxed_slice_exact(size as usize)?
@@ -625,7 +626,11 @@ impl Atom for MetaTagNamespaceAtom {
             .data_left()?
             .ok_or(Error::DecodeError("isomp4 (ilst): expected atom size to be known"))?;
 
-        // TODO: Apply a metadata limit.
+        const MAX_METADATA_ATOM_SIZE: u64 = 16 * 1024 * 1024;
+        if size > MAX_METADATA_ATOM_SIZE {
+            return decode_error("isomp4 (ilst): atom size exceeds limit");
+        }
+
         let buf = it.read_boxed_slice_exact(size as usize)?;
 
         // Do a lossy conversion because metadata should not prevent the demuxer from working.

--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -389,7 +389,12 @@ impl ParseChunk for AppSpecificChunk {
             return decode_error("aiff: malformed application-specific chunk");
         }
 
-        let data = reader.read_boxed_slice_exact((len - consumed) as usize)?;
+        let rem = len - consumed;
+        if rem > 16 * 1024 * 1024 {
+            return decode_error("aiff: application-specific chunk size exceeds 16MiB limit");
+        }
+
+        let data = reader.read_boxed_slice_exact(rem as usize)?;
 
         Ok(AppSpecificChunk { application, data })
     }
@@ -417,6 +422,11 @@ impl ParseChunk for CommentsChunk {
             let timestamp = reader.read_be_u32()?;
             let marker_id = reader.read_be_i16()?;
             let len = reader.read_be_u16()?;
+
+            if len as u32 > 16 * 1024 * 1024 {
+                return decode_error("aiff: comment chunk size exceeds 16MiB limit");
+            }
+
             let buf = reader.read_boxed_slice_exact(usize::from(len))?;
 
             comments.push(Comment { timestamp, marker_id, text: decode_string(&buf) });

--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -23,6 +23,9 @@ use symphonia_core::meta::{MetadataRevision, StandardTag, Tag};
 use symphonia_core::util::text;
 use symphonia_metadata::embedded::riff;
 
+/// Maximum length of a metadata chunk to prevent OOM on malformed files.
+const MAX_METADATA_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+
 use crate::common::{
     ChunkParser, FormatALaw, FormatData, FormatIeeeFloat, FormatMuLaw, FormatPcm, PacketInfo,
     ParseChunk, ParseChunkTag,
@@ -423,8 +426,8 @@ impl ParseChunk for CommentsChunk {
             let marker_id = reader.read_be_i16()?;
             let len = reader.read_be_u16()?;
 
-            if len as u32 > 16 * 1024 * 1024 {
-                return decode_error("aiff: comment chunk size exceeds 16MiB limit");
+            if len as u32 > MAX_METADATA_CHUNK_SIZE {
+                return decode_error("aiff: comment chunk size exceeds limit");
             }
 
             let buf = reader.read_boxed_slice_exact(usize::from(len))?;
@@ -442,6 +445,10 @@ pub struct TextChunk {
 
 impl ParseChunk for TextChunk {
     fn parse<B: ReadBytes>(reader: &mut B, tag: [u8; 4], len: u32) -> Result<Self> {
+        if len > MAX_METADATA_CHUNK_SIZE {
+            return decode_error("aiff: text chunk size exceeds limit");
+        }
+
         let text = reader.read_boxed_slice_exact(len as usize)?;
 
         let value = Arc::new(decode_string(&text));

--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -24,9 +24,9 @@ use symphonia_core::util::text;
 use symphonia_metadata::embedded::riff;
 
 /// Maximum length of a metadata chunk (such as application-specific, comments, or text) to
-/// prevent OOM on malformed files. A generous 16MiB ceiling is used to accommodate any valid large
+/// prevent OOM on malformed files. A generous ceiling is used to accommodate any valid large
 /// chunks while preventing runaway allocations.
-const MAX_METADATA_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+const MAX_METADATA_CHUNK_SIZE: u32 = 32 * 1024 * 1024;
 
 use crate::common::{
     ChunkParser, FormatALaw, FormatData, FormatIeeeFloat, FormatMuLaw, FormatPcm, PacketInfo,
@@ -395,8 +395,13 @@ impl ParseChunk for AppSpecificChunk {
         }
 
         let rem = len - consumed;
-        if rem > 16 * 1024 * 1024 {
-            return decode_error("aiff: application-specific chunk size exceeds 16MiB limit");
+
+        // Individual application-specific chunks should be reasonably small. This limit is intended
+        // to prevent OOMs from invalid formats without trunacting large chunks. Note that the
+        // specific chunk size is different than the MAX_METADATA_CHUNK_SIZE limit.
+        const MAX_APPLICATION_SPECIFIC_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+        if rem > MAX_APPLICATION_SPECIFIC_CHUNK_SIZE {
+            return decode_error("aiff: application-specific chunk size exceeds limit");
         }
 
         let data = reader.read_boxed_slice_exact(rem as usize)?;
@@ -427,7 +432,6 @@ impl ParseChunk for CommentsChunk {
             let timestamp = reader.read_be_u32()?;
             let marker_id = reader.read_be_i16()?;
             let len = reader.read_be_u16()?;
-
             if len as u32 > MAX_METADATA_CHUNK_SIZE {
                 return decode_error("aiff: comment chunk size exceeds limit");
             }

--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -23,7 +23,9 @@ use symphonia_core::meta::{MetadataRevision, StandardTag, Tag};
 use symphonia_core::util::text;
 use symphonia_metadata::embedded::riff;
 
-/// Maximum length of a metadata chunk to prevent OOM on malformed files.
+/// Maximum length of a metadata chunk (such as application-specific, comments, or text) to
+/// prevent OOM on malformed files. A generous 16MiB ceiling is used to accommodate any valid large
+/// chunks while preventing runaway allocations.
 const MAX_METADATA_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
 
 use crate::common::{

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -598,10 +598,9 @@ pub struct InfoChunk {
 
 impl ParseChunk for InfoChunk {
     fn parse<B: ReadBytes>(reader: &mut B, tag: [u8; 4], len: u32) -> Result<InfoChunk> {
-        if len > 16 * 1024 * 1024 {
-            return symphonia_core::errors::decode_error(
-                "riff (info): chunk size exceeds 16MiB limit",
-            );
+        const MAX_INFO_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+        if len > MAX_INFO_CHUNK_SIZE {
+            return symphonia_core::errors::decode_error("riff (info): chunk size exceeds limit");
         }
         let buf = reader.read_boxed_slice_exact(len as usize)?;
         Ok(InfoChunk { tag, buf })

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -598,9 +598,9 @@ pub struct InfoChunk {
 
 impl ParseChunk for InfoChunk {
     fn parse<B: ReadBytes>(reader: &mut B, tag: [u8; 4], len: u32) -> Result<InfoChunk> {
-        // INFO chunks contain textual metadata that should be relatively small. A 16MiB limit
+        // INFO chunks contain textual metadata that should be relatively small. This limit
         // acts as a safe guard against malicious sizes without truncating large valid metadata.
-        const MAX_INFO_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+        const MAX_INFO_CHUNK_SIZE: u32 = 32 * 1024 * 1024;
         if len > MAX_INFO_CHUNK_SIZE {
             return symphonia_core::errors::decode_error("riff (info): chunk size exceeds limit");
         }

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -598,6 +598,8 @@ pub struct InfoChunk {
 
 impl ParseChunk for InfoChunk {
     fn parse<B: ReadBytes>(reader: &mut B, tag: [u8; 4], len: u32) -> Result<InfoChunk> {
+        // INFO chunks contain textual metadata that should be relatively small. A 16MiB limit
+        // acts as a safe guard against malicious sizes without truncating large valid metadata.
         const MAX_INFO_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
         if len > MAX_INFO_CHUNK_SIZE {
             return symphonia_core::errors::decode_error("riff (info): chunk size exceeds limit");

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -598,7 +598,11 @@ pub struct InfoChunk {
 
 impl ParseChunk for InfoChunk {
     fn parse<B: ReadBytes>(reader: &mut B, tag: [u8; 4], len: u32) -> Result<InfoChunk> {
-        // TODO: Apply limit.
+        if len > 16 * 1024 * 1024 {
+            return symphonia_core::errors::decode_error(
+                "riff (info): chunk size exceeds 16MiB limit",
+            );
+        }
         let buf = reader.read_boxed_slice_exact(len as usize)?;
         Ok(InfoChunk { tag, buf })
     }

--- a/symphonia-metadata/src/ape.rs
+++ b/symphonia-metadata/src/ape.rs
@@ -240,9 +240,9 @@ enum ApeItemValue {
     Locator(String),
 }
 
-/// Maximum size of an APE tag item. APE tags can store embedded cover art, so a generous 16MiB
+/// Maximum size of an APE tag item. APE tags can store embedded cover art, so a generous
 /// limit is used to handle large images while preventing runaway allocations.
-const MAX_APE_ITEM_SIZE: usize = 16 * 1024 * 1024;
+const MAX_APE_ITEM_SIZE: usize = 32 * 1024 * 1024;
 
 /// An APE tag item.
 struct ApeItem {
@@ -255,7 +255,6 @@ impl ApeItem {
     fn read<B: ReadBytes>(reader: &mut B, header: &ApeHeader) -> Result<ApeItem> {
         // The length of the value in bytes.
         let len = reader.read_u32()? as usize;
-
         if len > MAX_APE_ITEM_SIZE {
             return decode_error("ape: item value length exceeds limit");
         }

--- a/symphonia-metadata/src/ape.rs
+++ b/symphonia-metadata/src/ape.rs
@@ -240,6 +240,9 @@ enum ApeItemValue {
     Locator(String),
 }
 
+/// Maximum length of an APE tag item to prevent OOM on malformed files.
+const MAX_APE_ITEM_SIZE: usize = 16 * 1024 * 1024;
+
 /// An APE tag item.
 struct ApeItem {
     key: String,
@@ -252,8 +255,8 @@ impl ApeItem {
         // The length of the value in bytes.
         let len = reader.read_u32()? as usize;
 
-        if len > 16 * 1024 * 1024 {
-            return decode_error("ape: item value length exceeds 16MiB limit");
+        if len > MAX_APE_ITEM_SIZE {
+            return decode_error("ape: item value length exceeds limit");
         }
 
         // Read flags.

--- a/symphonia-metadata/src/ape.rs
+++ b/symphonia-metadata/src/ape.rs
@@ -252,6 +252,10 @@ impl ApeItem {
         // The length of the value in bytes.
         let len = reader.read_u32()? as usize;
 
+        if len > 16 * 1024 * 1024 {
+            return decode_error("ape: item value length exceeds 16MiB limit");
+        }
+
         // Read flags.
         let flags = match header.version {
             ApeVersion::V1 => {

--- a/symphonia-metadata/src/ape.rs
+++ b/symphonia-metadata/src/ape.rs
@@ -240,7 +240,8 @@ enum ApeItemValue {
     Locator(String),
 }
 
-/// Maximum length of an APE tag item to prevent OOM on malformed files.
+/// Maximum size of an APE tag item. APE tags can store embedded cover art, so a generous 16MiB
+/// limit is used to handle large images while preventing runaway allocations.
 const MAX_APE_ITEM_SIZE: usize = 16 * 1024 * 1024;
 
 /// An APE tag item.

--- a/symphonia-metadata/src/embedded/flac.rs
+++ b/symphonia-metadata/src/embedded/flac.rs
@@ -26,6 +26,9 @@ use crate::embedded::vorbis;
 use crate::utils::id3v2::get_visual_key_from_picture_type;
 use crate::utils::images::try_get_image_info;
 
+/// Maximum length of a metadata block to prevent OOM on malformed files.
+const MAX_METADATA_BLOCK_SIZE: usize = 16 * 1024 * 1024;
+
 pub const FLAC_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_FLAC,
     short_name: "flac",
@@ -63,8 +66,11 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
     let type_enc = reader.read_be_u32()?;
 
     // Read the Media Type length in bytes.
-    // TODO: Apply a limit.
     let media_type_len = reader.read_be_u32()? as usize;
+
+    if media_type_len > MAX_METADATA_BLOCK_SIZE {
+        return decode_error("meta (flac): media type length exceeds 16MiB limit");
+    }
 
     // Read the Media Type bytes
     let media_type_buf = reader.read_boxed_slice_exact(media_type_len)?;
@@ -113,8 +119,11 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
     let _color_mode = reader.read_be_u32()?;
 
     // Read the image data length in bytes.
-    // TODO: Apply a limit.
     let data_len = reader.read_be_u32()? as usize;
+
+    if data_len > MAX_METADATA_BLOCK_SIZE {
+        return decode_error("meta (flac): image data length exceeds 16MiB limit");
+    }
 
     // Read the image data.
     let data = reader.read_boxed_slice_exact(data_len)?;

--- a/symphonia-metadata/src/embedded/flac.rs
+++ b/symphonia-metadata/src/embedded/flac.rs
@@ -69,7 +69,7 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
     let media_type_len = reader.read_be_u32()? as usize;
 
     if media_type_len > MAX_METADATA_BLOCK_SIZE {
-        return decode_error("meta (flac): media type length exceeds 16MiB limit");
+        return decode_error("meta (flac): media type length exceeds limit");
     }
 
     // Read the Media Type bytes
@@ -87,8 +87,11 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
     let mut tags = vec![];
 
     // Read the description length in bytes.
-    // TODO: Apply a limit.
     let desc_len = reader.read_be_u32()? as usize;
+
+    if desc_len > MAX_METADATA_BLOCK_SIZE {
+        return decode_error("meta (flac): description length exceeds 16MiB limit");
+    }
 
     // Read the description bytes.
     let desc_buf = reader.read_boxed_slice_exact(desc_len)?;

--- a/symphonia-metadata/src/embedded/flac.rs
+++ b/symphonia-metadata/src/embedded/flac.rs
@@ -67,7 +67,6 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
 
     // Read the Media Type length in bytes.
     let media_type_len = reader.read_be_u32()? as usize;
-
     if media_type_len > MAX_METADATA_BLOCK_SIZE {
         return decode_error("meta (flac): media type length exceeds limit");
     }
@@ -88,9 +87,8 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
 
     // Read the description length in bytes.
     let desc_len = reader.read_be_u32()? as usize;
-
     if desc_len > MAX_METADATA_BLOCK_SIZE {
-        return decode_error("meta (flac): description length exceeds 16MiB limit");
+        return decode_error("meta (flac): description length exceeds limit");
     }
 
     // Read the description bytes.
@@ -123,9 +121,8 @@ pub fn read_flac_picture_block<B: ReadBytes>(reader: &mut B) -> Result<Visual> {
 
     // Read the image data length in bytes.
     let data_len = reader.read_be_u32()? as usize;
-
     if data_len > MAX_METADATA_BLOCK_SIZE {
-        return decode_error("meta (flac): image data length exceeds 16MiB limit");
+        return decode_error("meta (flac): image data length exceeds limit");
     }
 
     // Read the image data.

--- a/symphonia-metadata/src/embedded/vorbis.rs
+++ b/symphonia-metadata/src/embedded/vorbis.rs
@@ -28,9 +28,6 @@ use crate::utils::base64;
 use crate::utils::images::try_get_image_info;
 use crate::utils::std_tag::*;
 
-/// Maximum length of a metadata block to prevent OOM on malformed files.
-const MAX_METADATA_BLOCK_SIZE: usize = 32 * 1024 * 1024;
-
 pub const VORBIS_COMMENT_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_VORBIS_COMMENT,
     short_name: "vorbis",
@@ -391,6 +388,8 @@ pub fn read_vorbis_comment<B: ReadBytes>(
         // Read the comment string length in bytes.
         let comment_length = reader.read_u32()?;
 
+        /// Maximum length of a metadata block to prevent OOM on malformed files.
+        const MAX_METADATA_BLOCK_SIZE: usize = 32 * 1024 * 1024;
         if comment_length as usize > MAX_METADATA_BLOCK_SIZE {
             return decode_error("meta (vorbis): comment length exceeds limit");
         }

--- a/symphonia-metadata/src/embedded/vorbis.rs
+++ b/symphonia-metadata/src/embedded/vorbis.rs
@@ -29,7 +29,7 @@ use crate::utils::images::try_get_image_info;
 use crate::utils::std_tag::*;
 
 /// Maximum length of a metadata block to prevent OOM on malformed files.
-const MAX_METADATA_BLOCK_SIZE: usize = 16 * 1024 * 1024;
+const MAX_METADATA_BLOCK_SIZE: usize = 32 * 1024 * 1024;
 
 pub const VORBIS_COMMENT_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_VORBIS_COMMENT,
@@ -392,7 +392,7 @@ pub fn read_vorbis_comment<B: ReadBytes>(
         let comment_length = reader.read_u32()?;
 
         if comment_length as usize > MAX_METADATA_BLOCK_SIZE {
-            return decode_error("meta (vorbis): comment length exceeds 16MiB limit");
+            return decode_error("meta (vorbis): comment length exceeds limit");
         }
 
         // Read the comment string.

--- a/symphonia-metadata/src/embedded/vorbis.rs
+++ b/symphonia-metadata/src/embedded/vorbis.rs
@@ -28,6 +28,9 @@ use crate::utils::base64;
 use crate::utils::images::try_get_image_info;
 use crate::utils::std_tag::*;
 
+/// Maximum length of a metadata block to prevent OOM on malformed files.
+const MAX_METADATA_BLOCK_SIZE: usize = 16 * 1024 * 1024;
+
 pub const VORBIS_COMMENT_METADATA_INFO: MetadataInfo = MetadataInfo {
     metadata: METADATA_ID_VORBIS_COMMENT,
     short_name: "vorbis",
@@ -388,7 +391,9 @@ pub fn read_vorbis_comment<B: ReadBytes>(
         // Read the comment string length in bytes.
         let comment_length = reader.read_u32()?;
 
-        // TODO: Apply a limit.
+        if comment_length as usize > MAX_METADATA_BLOCK_SIZE {
+            return decode_error("meta (vorbis): comment length exceeds 16MiB limit");
+        }
 
         // Read the comment string.
         let mut comment_data = vec![0; comment_length as usize];

--- a/symphonia-metadata/src/id3v2/frames.rs
+++ b/symphonia-metadata/src/id3v2/frames.rs
@@ -28,7 +28,7 @@ mod readers;
 use readers::*;
 
 /// Maximum length of a metadata block to prevent OOM on malformed files.
-const MAX_METADATA_BLOCK_SIZE: u64 = 16 * 1024 * 1024;
+const MAX_METADATA_BLOCK_SIZE: u64 = 256 * 1024 * 1024;
 
 // The following is a list of all standardized ID3v2.x frames for all ID3v2 major versions and their
 // implementation status ("S" column) in Symphonia.
@@ -647,7 +647,7 @@ pub fn read_id3v2p4_frame<B: ReadBytes + FiniteStream>(reader: &mut B) -> Result
     let data_size = size - flag_data_size;
 
     if u64::from(data_size) > MAX_METADATA_BLOCK_SIZE {
-        return decode_error("id3v2: frame size exceeds 16MiB limit");
+        return decode_error("id3v2: frame size exceeds limit");
     }
 
     // Frame group identifier byte. Used to group a set of frames. The frame group will be added as

--- a/symphonia-metadata/src/id3v2/frames.rs
+++ b/symphonia-metadata/src/id3v2/frames.rs
@@ -27,6 +27,9 @@ mod readers;
 
 use readers::*;
 
+/// Maximum length of a metadata block to prevent OOM on malformed files.
+const MAX_METADATA_BLOCK_SIZE: u64 = 16 * 1024 * 1024;
+
 // The following is a list of all standardized ID3v2.x frames for all ID3v2 major versions and their
 // implementation status ("S" column) in Symphonia.
 //
@@ -642,6 +645,10 @@ pub fn read_id3v2p4_frame<B: ReadBytes + FiniteStream>(reader: &mut B) -> Result
 
     // The size of the frame's body.
     let data_size = size - flag_data_size;
+
+    if u64::from(data_size) > MAX_METADATA_BLOCK_SIZE {
+        return decode_error("id3v2: frame size exceeds 16MiB limit");
+    }
 
     // Frame group identifier byte. Used to group a set of frames. The frame group will be added as
     // a sub-field to all produced tags.

--- a/symphonia-metadata/src/id3v2/frames.rs
+++ b/symphonia-metadata/src/id3v2/frames.rs
@@ -27,9 +27,6 @@ mod readers;
 
 use readers::*;
 
-/// Maximum length of a metadata block to prevent OOM on malformed files.
-const MAX_METADATA_BLOCK_SIZE: u64 = 256 * 1024 * 1024;
-
 // The following is a list of all standardized ID3v2.x frames for all ID3v2 major versions and their
 // implementation status ("S" column) in Symphonia.
 //
@@ -646,7 +643,11 @@ pub fn read_id3v2p4_frame<B: ReadBytes + FiniteStream>(reader: &mut B) -> Result
     // The size of the frame's body.
     let data_size = size - flag_data_size;
 
-    if u64::from(data_size) > MAX_METADATA_BLOCK_SIZE {
+    /// For ID3v2 frames, the total size of the tag is encoded using four bytes and
+    /// its integer format allows for 7 significant bits. This means that the
+    /// maximum total size for the ID3v2 container is 2^(4*7) = 256 MiB bytes.
+    const MAX_METADATA_BLOCK_SIZE: u32 = 256 * 1024 * 1024;
+    if data_size > MAX_METADATA_BLOCK_SIZE {
         return decode_error("id3v2: frame size exceeds limit");
     }
 

--- a/symphonia-metadata/src/id3v2/frames/readers.rs
+++ b/symphonia-metadata/src/id3v2/frames/readers.rs
@@ -332,8 +332,9 @@ pub fn read_apic_frame(mut reader: BufReader<'_>, frame: &FrameInfo<'_>) -> Resu
     }
 
     let bytes_avail = reader.bytes_available();
-    if bytes_avail > 16 * 1024 * 1024 {
-        return decode_error("id3v2 (apic): image size exceeds 16MiB limit");
+    const MAX_APIC_FRAME_SIZE: u64 = 16 * 1024 * 1024;
+    if bytes_avail > MAX_APIC_FRAME_SIZE {
+        return decode_error("id3v2 (apic): image size exceeds limit");
     }
 
     // The remainder of the APIC frame is the image data.

--- a/symphonia-metadata/src/id3v2/frames/readers.rs
+++ b/symphonia-metadata/src/id3v2/frames/readers.rs
@@ -332,9 +332,10 @@ pub fn read_apic_frame(mut reader: BufReader<'_>, frame: &FrameInfo<'_>) -> Resu
     }
 
     let bytes_avail = reader.bytes_available();
-    // APIC frames contain embedded cover art. We restrict this to 16MiB to easily handle
+
+    // APIC frames contain embedded cover art. We restrict this to easily handle
     // high-resolution images while preventing huge allocations from crafted tags.
-    const MAX_APIC_FRAME_SIZE: u64 = 16 * 1024 * 1024;
+    const MAX_APIC_FRAME_SIZE: u64 = 32 * 1024 * 1024;
     if bytes_avail > MAX_APIC_FRAME_SIZE {
         return decode_error("id3v2 (apic): image size exceeds limit");
     }

--- a/symphonia-metadata/src/id3v2/frames/readers.rs
+++ b/symphonia-metadata/src/id3v2/frames/readers.rs
@@ -326,13 +326,17 @@ pub fn read_apic_frame(mut reader: BufReader<'_>, frame: &FrameInfo<'_>) -> Resu
 
     let mut tags = vec![];
 
-    // Null-teriminated image description in specified encoding.
+    // Null-terminated image description in specified encoding.
     if let Some(desc) = read_string_ignore_empty(&mut reader, encoding)? {
         tags.push(Tag::new_from_parts("", "", Some(StandardTag::Description(Arc::from(desc)))));
     }
 
+    let bytes_avail = reader.bytes_available();
+    if bytes_avail > 16 * 1024 * 1024 {
+        return decode_error("id3v2 (apic): image size exceeds 16MiB limit");
+    }
+
     // The remainder of the APIC frame is the image data.
-    // TODO: Apply a limit.
     let data = Box::from(reader.read_buf_bytes_available_ref());
 
     // Try to get information about the image.

--- a/symphonia-metadata/src/id3v2/frames/readers.rs
+++ b/symphonia-metadata/src/id3v2/frames/readers.rs
@@ -332,6 +332,8 @@ pub fn read_apic_frame(mut reader: BufReader<'_>, frame: &FrameInfo<'_>) -> Resu
     }
 
     let bytes_avail = reader.bytes_available();
+    // APIC frames contain embedded cover art. We restrict this to 16MiB to easily handle
+    // high-resolution images while preventing huge allocations from crafted tags.
     const MAX_APIC_FRAME_SIZE: u64 = 16 * 1024 * 1024;
     if bytes_avail > MAX_APIC_FRAME_SIZE {
         return decode_error("id3v2 (apic): image size exceeds limit");


### PR DESCRIPTION
This CL resolves some long standing TODOs by adding maximum bounds checks to various data and metadata parsers. These checks are intended to be permissive, while also avoiding potential out-of-memory issues due to poorly crafted (or even malevolent) audio files.

Resolves #508.