### PR TITLE
mp3: Skip CRC in Xing/Info and VBRI tag heuristics

### DIFF
--- a/symphonia-bundle-mp3/src/common.rs
+++ b/symphonia-bundle-mp3/src/common.rs
@@ -13,6 +13,8 @@ use symphonia_core::errors::Result;
 use symphonia_core::io::BufReader;
 use symphonia_core::units::Duration;
 
+use crate::header::MPEG_HEADER_LEN;
+
 /// The MPEG audio version.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MpegVersion {
@@ -189,6 +191,12 @@ impl FrameHeader {
             ChannelMode::JointStereo(Mode::Layer3 { intensity, .. }) => intensity,
             _ => false,
         }
+    }
+
+    /// The size of the header itself including the optional CRC.
+    #[inline(always)]
+    pub fn header_size(&self) -> usize {
+        MPEG_HEADER_LEN + if self.has_crc { 2 } else { 0 }
     }
 
     /// Get the side information length.

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -1080,8 +1080,7 @@ mod tests {
         // Tag ID at offset 32 + 4 = 36
         buf[36..40].copy_from_slice(b"Xing");
 
-        // Currently this should return false because of the CRC, but it should return true.
-        // We want this to return true.
+        // Ensure the heuristic returns true even if a non-zero CRC is present.
         assert!(is_maybe_info_tag(&buf, &header));
     }
 
@@ -1111,7 +1110,7 @@ mod tests {
         // Tag ID at offset 36
         buf[36..40].copy_from_slice(b"VBRI");
 
-        // Currently this should return false because of the CRC, but it should return true.
+        // Ensure the heuristic returns true even if a non-zero CRC is present.
         assert!(is_maybe_vbri_tag(&buf, &header));
     }
 }

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -1052,7 +1052,7 @@ fn is_maybe_vbri_tag(buf: &[u8], header: &FrameHeader) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{MpegVersion, ChannelMode, Emphasis};
+    use crate::common::{ChannelMode, Emphasis, MpegVersion};
 
     #[test]
     fn test_is_maybe_info_tag_with_crc() {
@@ -1073,7 +1073,7 @@ mod tests {
 
         let mut buf = vec![0u8; 100];
         // Header
-        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]); 
+        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]);
         // CRC (non-zero)
         buf[4] = 0x12;
         buf[5] = 0x34;
@@ -1103,7 +1103,7 @@ mod tests {
 
         let mut buf = vec![0u8; 100];
         // Header
-        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]); 
+        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]);
         // CRC (non-zero)
         buf[4] = 0x12;
         buf[5] = 0x34;

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -964,7 +964,9 @@ fn is_maybe_info_tag(buf: &[u8], header: &FrameHeader) -> bool {
     }
 
     // The side information should be zeroed.
-    !buf[MPEG_HEADER_LEN..offset].iter().any(|&b| b != 0)
+    let start = MPEG_HEADER_LEN + if header.has_crc { 2 } else { 0 };
+
+    !buf[start..offset].iter().any(|&b| b != 0)
 }
 
 const VBRI_TAG_ID: [u8; 4] = *b"VBRI";
@@ -1042,5 +1044,74 @@ fn is_maybe_vbri_tag(buf: &[u8], header: &FrameHeader) -> bool {
     }
 
     // The bytes preceeding the VBRI tag (mostly the side information) should be all 0.
-    !buf[MPEG_HEADER_LEN..VBRI_TAG_OFFSET].iter().any(|&b| b != 0)
+    let start = MPEG_HEADER_LEN + if header.has_crc { 2 } else { 0 };
+
+    !buf[start..VBRI_TAG_OFFSET].iter().any(|&b| b != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{MpegVersion, ChannelMode, Emphasis};
+
+    #[test]
+    fn test_is_maybe_info_tag_with_crc() {
+        let header = FrameHeader {
+            version: MpegVersion::Mpeg1,
+            layer: MpegLayer::Layer3,
+            bitrate: 128000,
+            sample_rate: 44100,
+            sample_rate_idx: 0,
+            channel_mode: ChannelMode::Stereo,
+            emphasis: Emphasis::None,
+            is_copyrighted: false,
+            is_original: false,
+            has_padding: false,
+            has_crc: true,
+            frame_size: 417,
+        };
+
+        let mut buf = vec![0u8; 100];
+        // Header
+        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]); 
+        // CRC (non-zero)
+        buf[4] = 0x12;
+        buf[5] = 0x34;
+        // Tag ID at offset 32 + 4 = 36
+        buf[36..40].copy_from_slice(b"Xing");
+
+        // Currently this should return false because of the CRC, but it should return true.
+        // We want this to return true.
+        assert!(is_maybe_info_tag(&buf, &header));
+    }
+
+    #[test]
+    fn test_is_maybe_vbri_tag_with_crc() {
+        let header = FrameHeader {
+            version: MpegVersion::Mpeg1,
+            layer: MpegLayer::Layer3,
+            bitrate: 128000,
+            sample_rate: 44100,
+            sample_rate_idx: 0,
+            channel_mode: ChannelMode::Stereo,
+            emphasis: Emphasis::None,
+            is_copyrighted: false,
+            is_original: false,
+            has_padding: false,
+            has_crc: true,
+            frame_size: 417,
+        };
+
+        let mut buf = vec![0u8; 100];
+        // Header
+        buf[0..4].copy_from_slice(&[0xff, 0xfa, 0x90, 0x44]); 
+        // CRC (non-zero)
+        buf[4] = 0x12;
+        buf[5] = 0x34;
+        // Tag ID at offset 36
+        buf[36..40].copy_from_slice(b"VBRI");
+
+        // Currently this should return false because of the CRC, but it should return true.
+        assert!(is_maybe_vbri_tag(&buf, &header));
+    }
 }

--- a/symphonia-bundle-mp3/src/demuxer.rs
+++ b/symphonia-bundle-mp3/src/demuxer.rs
@@ -963,10 +963,8 @@ fn is_maybe_info_tag(buf: &[u8], header: &FrameHeader) -> bool {
         return false;
     }
 
-    // The side information should be zeroed.
-    let start = MPEG_HEADER_LEN + if header.has_crc { 2 } else { 0 };
-
-    !buf[start..offset].iter().any(|&b| b != 0)
+    // The side information, which follows the header and optional CRC, should be zeroed.
+    !buf[header.header_size()..offset].iter().any(|&b| b != 0)
 }
 
 const VBRI_TAG_ID: [u8; 4] = *b"VBRI";
@@ -1044,9 +1042,7 @@ fn is_maybe_vbri_tag(buf: &[u8], header: &FrameHeader) -> bool {
     }
 
     // The bytes preceeding the VBRI tag (mostly the side information) should be all 0.
-    let start = MPEG_HEADER_LEN + if header.has_crc { 2 } else { 0 };
-
-    !buf[start..VBRI_TAG_OFFSET].iter().any(|&b| b != 0)
+    !buf[header.header_size()..VBRI_TAG_OFFSET].iter().any(|&b| b != 0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses issue #516 - MP3 Xing/Info tags were rejected on CRC-protected frames. 

The heuristic checks in `is_maybe_info_tag` and `is_maybe_vbri_tag` were scanning the side information for zeros starting immediately after the 4-byte MPEG header. However, if the frame has the protection bit set, a 2-byte CRC follows the header. This CRC is almost never zero when utilized, causing the check to fail and the tag to be discarded. Although most MP3 files do not use CRC protection, this is a tightly scoped fix that makes Symphonia more compliant by checking the scan range to start after the CRC if it is present.

Verified with new in-module unit tests in the mp3 `demuxer.rs`. I would prefer a sample file to avoid regressions but do not have one readily available.