### PR TITLE
riff (aiff): Handle incorrect FORM chunk length

### DIFF
--- a/symphonia-format-riff/src/aiff/mod.rs
+++ b/symphonia-format-riff/src/aiff/mod.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
-use std::io::{Seek, SeekFrom};
+use std::io::{ErrorKind, Seek, SeekFrom};
 use std::sync::Arc;
 
 use symphonia_core::codecs::CodecParameters;
@@ -107,7 +107,23 @@ impl<'s> AiffReader<'s> {
         let mut builder = MetadataBuilder::new(AIFF_METADATA_INFO);
 
         // Scan over all chunks.
-        while let Some(chunk) = riff_chunks.next(&mut mss)? {
+        loop {
+            let chunk = match riff_chunks.next(&mut mss) {
+                Ok(chunk) => chunk,
+
+                // Stop reading without erroring on EOF since `riff_len` can be incorrect.
+                Err(Error::IoError(err)) if err.kind() == ErrorKind::UnexpectedEof => {
+                    break;
+                }
+
+                Err(err) => return Err(err),
+            };
+
+            let Some(chunk) = chunk
+            else {
+                break;
+            };
+
             match chunk {
                 RiffAiffChunks::Common(chunk) => {
                     // Only one common chunk is allowed.


### PR DESCRIPTION
## Motivation

I have an [example AIFF file](https://files.catbox.moe/y91hjl.aif) that can be decoded by ffmpeg and various music players, but can't be decoded by Symphonia (fails with `unexpected end of file`).

In the AIFF reader, if the top-level FORM chunk was written with a length larger than the actual length, the ChunksReader tries to read past the end of the stream and errors. This doesn't need to be fatal since the reader checks that it found the required chunks afterwards.

LLM usage disclosure: I investigated the error using LLMs, then reviewed and cleaned up the suggested fix, manually tested, and wrote the PR.

## Changes

Changed the AIFF reader to stop looping over chunks without erroring when it encounters an EOF error.

## Testing

`symphonia-check` output before:
```
Input Path: xxxxx.aif

Test interrupted by error: unexpected end of file
```

`symphonia-check` output after:
```
Input Path: xxxxx.aif


Test Results
=================================================

  Failed/Total Packets:            0/        7104
  Failed/Total Samples:            0/    16366392

  Remaining Target Samples:                     0
  Remaining Reference Samples:                  0

  Absolute Maximum Sample Delta:       0.00000000

PASS
```