### PR TITLE
layer3: Fix decoding failure on zero-length channels

### DIFF
--- a/symphonia-bundle-mp3/src/layer3/mod.rs
+++ b/symphonia-bundle-mp3/src/layer3/mod.rs
@@ -305,7 +305,7 @@ impl Layer3 {
                 let byte_index = part2_3_begin >> 3;
 
                 // Create a bit reader at the expected starting bit position.
-                let mut bs = if byte_index < main_data.len() {
+                let mut bs = if byte_index <= main_data.len() {
                     let mut bs = BitReaderLtr::new(&main_data[byte_index..]);
 
                     let bit_index = part2_3_begin & 0x7;


### PR DESCRIPTION
If a channel has part2_3_length == 0, skip creating the BitReaderLtr. This avoids an out-of-bounds check (mpa: invalid main_data offset) when the bit reservoir is exactly exhausted at granule boundaries.

This resolves decoding some non-standard MP3 files. For more context, see the related issue in Chromium, [cl/532860173](https://crbug.com/532860173).

Fixes #529 