### PR TITLE
riff (wav): support MPEG audio (MP3) in WAVE containers

### DIFF
--- a/symphonia-format-riff/src/aiff/chunks.rs
+++ b/symphonia-format-riff/src/aiff/chunks.rs
@@ -192,6 +192,9 @@ impl CommonChunk {
             FormatData::Adpcm(_) => {
                 unsupported_error("aiff: packet info not implemented for format Adpcm")
             }
+            FormatData::Mpeg(_) => {
+                unsupported_error("aiff: packet info not implemented for format Mpeg")
+            }
         }
     }
 }
@@ -244,6 +247,9 @@ impl fmt::Display for CommonChunk {
             }
             FormatData::Adpcm(_) => {
                 writeln!(f, "\tformat_data: Adpcm DISPLAY UNSUPPORTED {{")?;
+            }
+            FormatData::Mpeg(_) => {
+                writeln!(f, "\tformat_data: Mpeg DISPLAY UNSUPPORTED {{")?;
             }
         };
 

--- a/symphonia-format-riff/src/common.rs
+++ b/symphonia-format-riff/src/common.rs
@@ -196,6 +196,7 @@ pub enum FormatData {
     Extensible(FormatExtensible),
     ALaw(FormatALaw),
     MuLaw(FormatMuLaw),
+    Mpeg(FormatMpeg),
 }
 
 pub struct FormatPcm {
@@ -324,6 +325,22 @@ impl FormatMuLaw {
     pub fn make_packet_info(&self) -> Result<PacketInfo> {
         let num_channels = self.channels.count() as u32;
         PacketInfo::without_blocks(num_channels)
+    }
+}
+
+pub struct FormatMpeg {
+    /// Channel bitmask.
+    pub channels: Channels,
+    /// Codec ID (`CODEC_ID_MP1`, `CODEC_ID_MP2`, or `CODEC_ID_MP3`).
+    pub codec: AudioCodecId,
+}
+
+impl FormatMpeg {
+    pub fn make_packet_info(&self) -> Result<PacketInfo> {
+        // MPEG audio frames are variable-length and are packetized frame-by-frame directly from
+        // the data chunk (see `wave::mpeg`), so the block-based packet model is not used for
+        // framing. A unit block keeps the shared duration/seek helpers well-defined.
+        PacketInfo::without_blocks(1)
     }
 }
 
@@ -464,6 +481,9 @@ pub fn append_format_params(
         }
         FormatData::MuLaw(mulaw) => {
             codec_params.for_codec(mulaw.codec).with_channels(mulaw.channels);
+        }
+        FormatData::Mpeg(mpeg) => {
+            codec_params.for_codec(mpeg.codec).with_channels(mpeg.channels);
         }
     }
 }

--- a/symphonia-format-riff/src/wave/chunks.rs
+++ b/symphonia-format-riff/src/wave/chunks.rs
@@ -11,7 +11,7 @@ use symphonia_core::audio::AmbisonicBFormat;
 use symphonia_core::audio::{ChannelLabel, Channels, Position};
 use symphonia_core::codecs::audio::AudioCodecId;
 use symphonia_core::codecs::audio::well_known::{
-    CODEC_ID_ADPCM_IMA_WAV, CODEC_ID_ADPCM_MS, CODEC_ID_PCM_ALAW, CODEC_ID_PCM_F32LE,
+    CODEC_ID_ADPCM_IMA_WAV, CODEC_ID_ADPCM_MS, CODEC_ID_MP3, CODEC_ID_PCM_ALAW, CODEC_ID_PCM_F32LE,
     CODEC_ID_PCM_F64LE, CODEC_ID_PCM_MULAW, CODEC_ID_PCM_S16LE, CODEC_ID_PCM_S24LE,
     CODEC_ID_PCM_S32LE, CODEC_ID_PCM_U8,
 };
@@ -24,7 +24,8 @@ use symphonia_metadata::embedded::riff;
 
 use crate::common::{
     ByteOrder, ChunkParser, ChunksReader, FormatALaw, FormatAdpcm, FormatData, FormatExtensible,
-    FormatIeeeFloat, FormatMuLaw, FormatPcm, NullChunks, PacketInfo, ParseChunk, ParseChunkTag,
+    FormatIeeeFloat, FormatMpeg, FormatMuLaw, FormatPcm, NullChunks, PacketInfo, ParseChunk,
+    ParseChunkTag,
 };
 
 use log::info;
@@ -396,6 +397,24 @@ impl WaveFormatChunk {
         Ok(FormatData::MuLaw(FormatMuLaw { codec: CODEC_ID_PCM_MULAW, channels }))
     }
 
+    fn read_mpeg_fmt<B: ReadBytes>(
+        reader: &mut B,
+        num_channels: u16,
+        len: u32,
+    ) -> Result<FormatData> {
+        // The fmt chunk carries a WAVEFORMATEX header followed by an MPEGLAYER3WAVEFORMAT
+        // extension (cbSize, then wID/fdwFlags/nBlockSize/nFramesPerBlock/nCodecDelay). None of the
+        // extension is needed: MPEG audio frames are self-describing and are framed from the data
+        // chunk (see `wave::mpeg`). Consume any bytes beyond the 16-byte base fmt so the next chunk
+        // reads from the right position.
+        if len > 16 {
+            reader.ignore_bytes(u64::from(len - 16))?;
+        }
+
+        let channels = map_wave_channel_count(num_channels)?;
+        Ok(FormatData::Mpeg(FormatMpeg { codec: CODEC_ID_MP3, channels }))
+    }
+
     pub(crate) fn packet_info(&self) -> Result<PacketInfo> {
         match &self.format_data {
             FormatData::Pcm(pcm) => pcm.make_packet_info(),
@@ -404,6 +423,7 @@ impl WaveFormatChunk {
             FormatData::ALaw(alaw) => alaw.make_packet_info(),
             FormatData::MuLaw(mulaw) => mulaw.make_packet_info(),
             FormatData::Extensible(ext) => ext.make_packet_info(),
+            FormatData::Mpeg(mpeg) => mpeg.make_packet_info(),
         }
     }
 }
@@ -431,6 +451,7 @@ impl ParseChunk for WaveFormatChunk {
         const WAVE_FORMAT_ALAW: u16 = 0x0006;
         const WAVE_FORMAT_MULAW: u16 = 0x0007;
         const WAVE_FORMAT_ADPCM_IMA: u16 = 0x0011;
+        const WAVE_FORMAT_MPEGLAYER3: u16 = 0x0055;
         const WAVE_FORMAT_EXTENSIBLE: u16 = 0xfffe;
 
         let format_data = match format {
@@ -468,6 +489,8 @@ impl ParseChunk for WaveFormatChunk {
                 len,
                 CODEC_ID_ADPCM_IMA_WAV,
             ),
+            // The MPEG-1 Audio Layer III (MP3) Format.
+            WAVE_FORMAT_MPEGLAYER3 => Self::read_mpeg_fmt(reader, num_channels, len),
             // Unsupported format.
             _ => return unsupported_error("wav: unsupported wave format"),
         }?;
@@ -527,6 +550,11 @@ impl fmt::Display for WaveFormatChunk {
                 writeln!(f, "\tformat_data: MuLaw {{")?;
                 writeln!(f, "\t\tchannels: {},", mulaw.channels)?;
                 writeln!(f, "\t\tcodec: {},", mulaw.codec)?;
+            }
+            FormatData::Mpeg(ref mpeg) => {
+                writeln!(f, "\tformat_data: Mpeg {{")?;
+                writeln!(f, "\t\tchannels: {},", mpeg.channels)?;
+                writeln!(f, "\t\tcodec: {},", mpeg.codec)?;
             }
         };
 

--- a/symphonia-format-riff/src/wave/mod.rs
+++ b/symphonia-format-riff/src/wave/mod.rs
@@ -22,9 +22,11 @@ use symphonia_core::support_format;
 use log::{debug, error};
 
 use crate::common::{
-    ByteOrder, ChunksReader, PacketInfo, append_data_params, append_format_params, next_packet,
+    ByteOrder, ChunksReader, FormatData, PacketInfo, append_data_params, append_format_params,
+    next_packet,
 };
 mod chunks;
+mod mpeg;
 use chunks::*;
 
 /// WAVE is actually a RIFF stream, with a "RIFF" ASCII stream marker.
@@ -56,6 +58,11 @@ pub struct WavReader<'s> {
     packet_info: PacketInfo,
     data_start_pos: u64,
     data_end_pos: Option<u64>,
+    /// True when the data chunk holds an MPEG audio elementary stream (`WAVE_FORMAT_MPEGLAYER3`),
+    /// which is packetized frame-by-frame rather than by the block-based `packet_info`.
+    is_mpeg: bool,
+    /// Running presentation timestamp (in samples) for the next MPEG packet.
+    mpeg_ts: u64,
 }
 
 impl<'s> WavReader<'s> {
@@ -97,6 +104,7 @@ impl<'s> WavReader<'s> {
         let mut metadata: MetadataLog = Default::default();
         let mut packet_info = None;
         let mut fact = None;
+        let mut is_mpeg = false;
 
         loop {
             let chunk = riff_chunks.next(&mut mss)?;
@@ -111,6 +119,9 @@ impl<'s> WavReader<'s> {
             match chunk {
                 RiffWaveChunks::Format(fmt) => {
                     let format = fmt.parse(&mut mss)?;
+
+                    // MPEG audio in WAV is framed from the elementary stream, not by fixed blocks.
+                    is_mpeg = matches!(format.format_data, FormatData::Mpeg(_));
 
                     // The Format chunk contains the block_align field and possible additional
                     // information to handle packetization and seeking.
@@ -144,6 +155,18 @@ impl<'s> WavReader<'s> {
                     let data_start_pos = mss.pos();
                     let data_end_pos = data.len.map(|len| data_start_pos + u64::from(len));
 
+                    // For MPEG audio the elementary stream is authoritative for the exact codec
+                    // (Layer I/II/III) and sample rate, so refine the codec parameters from the
+                    // first frame, then rewind so the first packet is read in full.
+                    if is_mpeg {
+                        if let Some((first, _)) =
+                            mpeg::read_frame(&mut mss, data_end_pos.unwrap_or(u64::MAX))?
+                        {
+                            codec_params.for_codec(first.codec).with_sample_rate(first.sample_rate);
+                        }
+                        mss.seek_buffered(data_start_pos);
+                    }
+
                     // Create the track.
                     let mut track = Track::new(0);
 
@@ -159,9 +182,13 @@ impl<'s> WavReader<'s> {
                         append_fact_params(&mut track, fact);
                     }
 
-                    // Append Data chunk fields to track.
+                    // Append Data chunk fields to track. For MPEG audio the block-based frame count
+                    // would be meaningless (frames are variable-length), so leave the frame count
+                    // unset rather than derive a bogus duration from the byte length.
                     if let Some(data_len) = data.len {
-                        append_data_params(&mut track, u64::from(data_len), &packet_info);
+                        if !is_mpeg {
+                            append_data_params(&mut track, u64::from(data_len), &packet_info);
+                        }
                     }
 
                     // Instantiate the reader.
@@ -174,6 +201,8 @@ impl<'s> WavReader<'s> {
                         packet_info,
                         data_start_pos,
                         data_end_pos,
+                        is_mpeg,
+                        mpeg_ts: 0,
                     });
                 }
             }
@@ -228,6 +257,15 @@ impl FormatReader for WavReader<'_> {
     }
 
     fn next_packet(&mut self) -> Result<Option<Packet>> {
+        // MPEG audio in WAV is framed from the elementary stream, one MPEG frame per packet.
+        if self.is_mpeg {
+            return mpeg::next_packet(
+                &mut self.reader,
+                self.data_end_pos.unwrap_or(u64::MAX),
+                &mut self.mpeg_ts,
+            );
+        }
+
         next_packet(
             &mut self.reader,
             &self.packet_info,
@@ -327,5 +365,79 @@ impl FormatReader for WavReader<'_> {
         Self: 's,
     {
         self.reader
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use symphonia_core::codecs::audio::well_known::CODEC_ID_MP3;
+    use symphonia_core::formats::FormatReader;
+
+    use super::*;
+
+    /// A single MPEG-1 Layer III frame: 128 kbps, 44.1 kHz, stereo (417 bytes). The body is zeroed;
+    /// only framing is under test, not decoding.
+    fn mp3_frame() -> Vec<u8> {
+        let mut frame = vec![0u8; 417];
+        frame[0..4].copy_from_slice(&0xFFFB_9000u32.to_be_bytes());
+        frame
+    }
+
+    /// Wrap concatenated MPEG audio frames in a minimal RIFF/WAVE container whose `fmt ` chunk
+    /// declares `WAVE_FORMAT_MPEGLAYER3` (0x0055).
+    fn riff_mpeglayer3(frames: &[Vec<u8>]) -> Vec<u8> {
+        let data: Vec<u8> = frames.iter().flatten().copied().collect();
+
+        // MPEGLAYER3WAVEFORMAT: 16-byte WAVEFORMATEX base + 2-byte cbSize + 12-byte extension.
+        let mut fmt = Vec::new();
+        fmt.extend_from_slice(&0x0055u16.to_le_bytes()); // wFormatTag
+        fmt.extend_from_slice(&2u16.to_le_bytes()); // nChannels
+        fmt.extend_from_slice(&44_100u32.to_le_bytes()); // nSamplesPerSec
+        fmt.extend_from_slice(&16_000u32.to_le_bytes()); // nAvgBytesPerSec
+        fmt.extend_from_slice(&1u16.to_le_bytes()); // nBlockAlign
+        fmt.extend_from_slice(&0u16.to_le_bytes()); // wBitsPerSample
+        fmt.extend_from_slice(&12u16.to_le_bytes()); // cbSize
+        fmt.extend_from_slice(&1u16.to_le_bytes()); // wID (MPEG Layer 3)
+        fmt.extend_from_slice(&0u32.to_le_bytes()); // fdwFlags
+        fmt.extend_from_slice(&417u16.to_le_bytes()); // nBlockSize
+        fmt.extend_from_slice(&1u16.to_le_bytes()); // nFramesPerBlock
+        fmt.extend_from_slice(&0u16.to_le_bytes()); // nCodecDelay
+
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WAVE");
+        body.extend_from_slice(b"fmt ");
+        body.extend_from_slice(&(fmt.len() as u32).to_le_bytes());
+        body.extend_from_slice(&fmt);
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        body.extend_from_slice(&data);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn reads_mpeg_layer3_in_wav() {
+        let frames = vec![mp3_frame(), mp3_frame()];
+        let bytes = riff_mpeglayer3(&frames);
+        let mss = MediaSourceStream::new(Box::new(Cursor::new(bytes)), Default::default());
+        let mut reader = WavReader::try_new(mss, FormatOptions::default()).unwrap();
+
+        // The track is recognised as MP3 at 44.1 kHz.
+        let params = reader.tracks()[0].codec_params.as_ref().unwrap().audio().unwrap();
+        assert_eq!(params.codec, CODEC_ID_MP3);
+        assert_eq!(params.sample_rate, Some(44_100));
+
+        // Each MPEG frame is emitted as one packet, byte-for-byte, then the stream ends.
+        let packet = reader.next_packet().unwrap().unwrap();
+        assert_eq!(&packet.data[..], &frames[0][..]);
+        let packet = reader.next_packet().unwrap().unwrap();
+        assert_eq!(&packet.data[..], &frames[1][..]);
+        assert!(reader.next_packet().unwrap().is_none());
     }
 }

--- a/symphonia-format-riff/src/wave/mpeg.rs
+++ b/symphonia-format-riff/src/wave/mpeg.rs
@@ -1,0 +1,224 @@
+// Symphonia
+// Copyright (c) 2019-2026 The Project Symphonia Developers.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Minimal MPEG-1/2/2.5 Audio (Layer I/II/III) frame framing, just enough to packetize the
+//! `data` chunk of an MPEG-audio-in-WAV file (`WAVE_FORMAT_MPEGLAYER3`, tag `0x0055`) one frame at
+//! a time.
+//!
+//! The `data` chunk of such a file is a plain MPEG audio elementary stream. MPEG audio frames are
+//! self-describing and variable-length, so — unlike the block-aligned PCM/ADPCM formats — they
+//! cannot be packetized with `PacketInfo`; each frame's length is computed from its own header.
+//!
+//! The bit-rate tables and frame-size arithmetic mirror `symphonia-bundle-mp3`'s `header.rs`. They
+//! are duplicated here rather than shared because a format crate must not depend on a codec bundle;
+//! only the small amount of header parsing needed to find frame boundaries is reproduced.
+
+use symphonia_core::codecs::audio::AudioCodecId;
+use symphonia_core::codecs::audio::well_known::{CODEC_ID_MP1, CODEC_ID_MP2, CODEC_ID_MP3};
+use symphonia_core::errors::Result;
+use symphonia_core::io::{MediaSourceStream, ReadBytes};
+use symphonia_core::packet::Packet;
+use symphonia_core::units::{Duration, Timestamp};
+
+// Bit-rate lookup tables (bits/sec), indexed by the 4-bit bit-rate field.
+const BIT_RATES_MPEG1_L1: [u32; 15] = [
+    0, 32_000, 64_000, 96_000, 128_000, 160_000, 192_000, 224_000, 256_000, 288_000, 320_000,
+    352_000, 384_000, 416_000, 448_000,
+];
+const BIT_RATES_MPEG1_L2: [u32; 15] = [
+    0, 32_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 160_000, 192_000, 224_000,
+    256_000, 320_000, 384_000,
+];
+const BIT_RATES_MPEG1_L3: [u32; 15] = [
+    0, 32_000, 40_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 160_000, 192_000,
+    224_000, 256_000, 320_000,
+];
+const BIT_RATES_MPEG2_L1: [u32; 15] = [
+    0, 32_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 144_000, 160_000, 176_000,
+    192_000, 224_000, 256_000,
+];
+const BIT_RATES_MPEG2_L23: [u32; 15] = [
+    0, 8_000, 16_000, 24_000, 32_000, 40_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000,
+    128_000, 144_000, 160_000,
+];
+
+/// The audio parameters described by an MPEG audio frame header.
+pub struct MpegFrameFormat {
+    /// Codec (`CODEC_ID_MP1`, `CODEC_ID_MP2`, or `CODEC_ID_MP3`).
+    pub codec: AudioCodecId,
+    /// Sampling rate in Hz.
+    pub sample_rate: u32,
+    /// Number of PCM samples the frame decodes to.
+    pub samples_per_frame: u64,
+}
+
+/// Parses a 32-bit MPEG audio frame header word into its audio parameters and the total frame
+/// length in bytes (header + body). Returns `None` if the word is not a valid, supported frame
+/// header, which is also how the caller detects a false sync.
+fn parse_header(word: u32) -> Option<(MpegFrameFormat, usize)> {
+    // The header begins with an 11-bit sync word (all ones).
+    if word & 0xffe0_0000 != 0xffe0_0000 {
+        return None;
+    }
+
+    let version = (word >> 19) & 0x3; // 0b00 = 2.5, 0b10 = 2, 0b11 = 1 (0b01 reserved)
+    let layer = (word >> 17) & 0x3; // 0b01 = III, 0b10 = II, 0b11 = I (0b00 reserved)
+    let bitrate_idx = ((word >> 12) & 0xf) as usize;
+    let sr_idx = (word >> 10) & 0x3;
+    let padding = (word >> 9) & 0x1;
+
+    // Reject reserved or unsupported fields. Free-format (bit-rate index 0) is not supported.
+    if version == 0b01 || layer == 0b00 || bitrate_idx == 0 || bitrate_idx == 0xf || sr_idx == 0b11
+    {
+        return None;
+    }
+
+    let is_mpeg1 = version == 0b11;
+
+    let bitrate = match (is_mpeg1, layer) {
+        (true, 0b11) => BIT_RATES_MPEG1_L1[bitrate_idx],
+        (true, 0b10) => BIT_RATES_MPEG1_L2[bitrate_idx],
+        (true, 0b01) => BIT_RATES_MPEG1_L3[bitrate_idx],
+        (false, 0b11) => BIT_RATES_MPEG2_L1[bitrate_idx],
+        (false, _) => BIT_RATES_MPEG2_L23[bitrate_idx],
+        _ => return None,
+    };
+
+    let sample_rate = match (version, sr_idx) {
+        (0b11, 0b00) => 44_100,
+        (0b11, 0b01) => 48_000,
+        (0b11, 0b10) => 32_000,
+        (0b10, 0b00) => 22_050,
+        (0b10, 0b01) => 24_000,
+        (0b10, 0b10) => 16_000,
+        (0b00, 0b00) => 11_025,
+        (0b00, 0b01) => 12_000,
+        (0b00, 0b10) => 8_000,
+        _ => return None,
+    };
+
+    // Codec, samples-per-frame, and the frame-size factor/slot-size per ISO-11172 §2.4.3.1.
+    let (codec, samples_per_frame, factor, slot_size) = match layer {
+        0b11 => (CODEC_ID_MP1, 384, 12, 4),            // Layer I
+        0b10 => (CODEC_ID_MP2, 1152, 144, 1),          // Layer II
+        _ if is_mpeg1 => (CODEC_ID_MP3, 1152, 144, 1), // Layer III, MPEG 1
+        _ => (CODEC_ID_MP3, 576, 72, 1),               // Layer III, MPEG 2 / 2.5
+    };
+
+    let frame_len = ((factor * bitrate / sample_rate + padding) * slot_size) as usize;
+
+    // A frame must be at least large enough to hold its own header.
+    if frame_len <= 4 {
+        return None;
+    }
+
+    Some((MpegFrameFormat { codec, sample_rate, samples_per_frame }, frame_len))
+}
+
+/// Synchronises to and reads the next whole MPEG audio frame (header and body) from the `data`
+/// chunk, stopping at `end_pos`. Returns the frame's audio parameters and its bytes, or `None` at
+/// the end of the data chunk.
+pub fn read_frame(
+    reader: &mut MediaSourceStream<'_>,
+    end_pos: u64,
+) -> Result<Option<(MpegFrameFormat, Vec<u8>)>> {
+    let mut sync = 0u32;
+    let mut have = 0u32;
+
+    loop {
+        if reader.pos() >= end_pos {
+            return Ok(None);
+        }
+
+        let byte = match reader.read_u8() {
+            Ok(byte) => byte,
+            // The data chunk ended part way through a sync search; treat as end of stream.
+            Err(_) => return Ok(None),
+        };
+
+        sync = (sync << 8) | u32::from(byte);
+        have += 1;
+
+        // A sync word is only meaningful once four bytes have been shifted in.
+        if have < 4 {
+            continue;
+        }
+
+        if let Some((format, frame_len)) = parse_header(sync) {
+            // The final frame may be truncated by the end of the data chunk (or file). If the whole
+            // body is not available, stop cleanly rather than reading past the audio or failing on
+            // a partial frame — a mid-stream demux failure would otherwise discard the whole hash.
+            if reader.pos().saturating_add(frame_len as u64 - 4) > end_pos {
+                return Ok(None);
+            }
+            let mut frame = vec![0u8; frame_len];
+            frame[0..4].copy_from_slice(&sync.to_be_bytes());
+            if reader.read_buf_exact(&mut frame[4..]).is_err() {
+                return Ok(None);
+            }
+            return Ok(Some((format, frame)));
+        }
+    }
+}
+
+/// Reads the next MPEG audio frame from the `data` chunk and wraps it in a [`Packet`], advancing
+/// `next_ts` by the frame's sample count. Returns `None` at the end of the data chunk.
+pub fn next_packet(
+    reader: &mut MediaSourceStream<'_>,
+    end_pos: u64,
+    next_ts: &mut u64,
+) -> Result<Option<Packet>> {
+    let Some((format, frame)) = read_frame(reader, end_pos)?
+    else {
+        return Ok(None);
+    };
+
+    let pts = match Timestamp::try_from(*next_ts) {
+        Ok(pts) => pts,
+        Err(_) => return Ok(None),
+    };
+    let dur = Duration::from(format.samples_per_frame);
+    *next_ts = next_ts.saturating_add(format.samples_per_frame);
+
+    Ok(Some(Packet::new(0, pts, dur, frame)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mpeg1_layer3_header() {
+        // MPEG-1 Layer III, 128 kbps, 44.1 kHz, stereo, no padding.
+        let (fmt, len) = parse_header(0xFFFB_9000).unwrap();
+        assert_eq!(fmt.codec, CODEC_ID_MP3);
+        assert_eq!(fmt.sample_rate, 44_100);
+        assert_eq!(fmt.samples_per_frame, 1152);
+        assert_eq!(len, 417); // 144 * 128000 / 44100
+
+        // The padding bit adds one slot (one byte for Layer III).
+        let (_, padded_len) = parse_header(0xFFFB_9200).unwrap();
+        assert_eq!(padded_len, 418);
+    }
+
+    #[test]
+    fn parses_mpeg2_layer3_header() {
+        // MPEG-2 Layer III, 64 kbps, 22.05 kHz — half the samples per frame.
+        let (fmt, len) = parse_header(0xFFF3_8000).unwrap();
+        assert_eq!(fmt.codec, CODEC_ID_MP3);
+        assert_eq!(fmt.sample_rate, 22_050);
+        assert_eq!(fmt.samples_per_frame, 576);
+        assert_eq!(len, 208); // 72 * 64000 / 22050
+    }
+
+    #[test]
+    fn rejects_invalid_headers() {
+        assert!(parse_header(0x0000_0000).is_none()); // no sync word
+        assert!(parse_header(0xFFFF_FFFF).is_none()); // reserved bit-rate (0xf)
+        assert!(parse_header(0xFFE0_0000).is_none()); // free-format bit-rate (0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for MPEG audio stored in a WAVE container (MP3-in-WAV) to the WAVE reader.

The `fmt ` chunk parser in `symphonia-format-riff` handled only the PCM-family and ADPCM format tags; `WAVE_FORMAT_MPEGLAYER3` (`0x0055`) fell through to the `unsupported_error("wav: unsupported wave format")` catch-all. As a result an MP3 wrapped in a WAVE container failed to demux (`probe` errored, no track), even though Symphonia already ships a complete MP3 stack in `symphonia-bundle-mp3`. It was a container-wiring gap, not a codec gap — the `data` chunk of such a file is a plain MPEG audio elementary stream that the existing decoder can read once it is handed frame-aligned packets.

## What this does

- Recognises `fmt ` tag `0x0055` and produces a `CODEC_ID_MP3` track. The exact codec (Layer I/II/III) and sample rate are read from the first frame of the elementary stream, which is authoritative, rather than trusting the `fmt` header.
- MPEG audio frames are self-describing and variable-length, so they cannot be packetized by the block-based `PacketInfo` used for PCM/ADPCM. A small, self-contained frame reader (`wave::mpeg`) parses each frame header to find the frame boundary and emits **one MPEG frame per packet**, matching what `MpaReader` produces, so the MP3 decoder decodes it unchanged. Its bit-rate tables and frame-size arithmetic mirror `symphonia-bundle-mp3`'s `header.rs`; the logic is reproduced locally because a format crate must not depend on a codec bundle. (If preferred, this small amount of shared MPEG framing could later move into `symphonia-common` and be used by both crates.)
- A final frame truncated by the end of the `data` chunk (or file) stops the stream cleanly instead of erroring.

## Testing

- Unit tests for the frame-header arithmetic — MPEG 1 and MPEG 2 Layer III, the padding bit, and invalid/false-sync headers.
- A round-trip test that builds an in-memory `0x0055` WAVE file and checks the track is recognised as MP3 at the right sample rate and that each MPEG frame is emitted as one packet byte-for-byte.
- Verified end-to-end against real-world MP3-in-WAV files from a music library, including the double-wrapped `ID3 + RIFF/WAVE + MP3` variant. Before: `codec = None`, no demux. After: they decode with the correct codec/sample-rate/duration and produce a valid fingerprint. The demuxed compressed packets are **byte-identical** to those a plain-`.mp3`-container copy of the same audio produces (BLAKE3 of the concatenated packets matches), i.e. re-containerising does not change the audio the reader yields.

## Notes / open questions (draft)

- Scope is `0x0055` (MPEGLAYER3). `0x0050` (`WAVE_FORMAT_MPEG`, MPEG-1 Layer I/II) would be a small follow-up on the same path — the frame reader already handles all three layers.
- Seeking still uses the block-based path (approximate for variable-length MPEG frames). Happy to add frame-accurate seeking if desired.
- Opened as a draft for feedback on the approach — in particular whether you'd prefer the MPEG framing to live in `symphonia-common` rather than being duplicated in the WAVE reader.
