### PR TITLE
Update packet.track_id() to packet.track_id in GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -291,7 +291,7 @@ fn main() {
         }
 
         // If the packet does not belong to the selected track, skip over it.
-        if packet.track_id() != track_id {
+        if packet.track_id != track_id {
             continue;
         }
 

--- a/symphonia/examples/basic-interleaved.rs
+++ b/symphonia/examples/basic-interleaved.rs
@@ -6,10 +6,10 @@ use symphonia::core::audio::sample::Sample;
 use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::errors::Error;
 use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::TrackType;
 use symphonia::core::formats::probe::Hint;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia_core::formats::TrackType;
 
 fn main() {
     // Get command line arguments.

--- a/symphonia/examples/getting-started.rs
+++ b/symphonia/examples/getting-started.rs
@@ -1,8 +1,8 @@
 use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::errors::Error;
 use symphonia::core::formats::FormatOptions;
-use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::TrackType;
+use symphonia::core::formats::probe::Hint;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 

--- a/symphonia/examples/getting-started.rs
+++ b/symphonia/examples/getting-started.rs
@@ -2,9 +2,9 @@ use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::errors::Error;
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::formats::probe::Hint;
+use symphonia::core::formats::TrackType;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::formats::TrackType;
 
 fn main() {
     // Get the first command line argument.

--- a/symphonia/examples/getting-started.rs
+++ b/symphonia/examples/getting-started.rs
@@ -4,7 +4,7 @@ use symphonia::core::formats::FormatOptions;
 use symphonia::core::formats::probe::Hint;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia_core::formats::TrackType;
+use symphonia::core::formats::TrackType;
 
 fn main() {
     // Get the first command line argument.


### PR DESCRIPTION
The decode loop example in GETTING_STARTED.md references `packet.track_id()` as a method call, but `track_id` is a field on `Packet`. This causes a compile error for anyone following the guide. This was fixed in the example file in 764d299 but GETTING_STARTED.md was not updated.

