### PR TITLE
isomp4: relax the pending atom check for seekable source

### DIFF
--- a/symphonia-format-isomp4/src/atoms/mod.rs
+++ b/symphonia-format-isomp4/src/atoms/mod.rs
@@ -853,7 +853,9 @@ impl<R: ReadAtom> AtomIterator<R> {
         R: MediaSource,
     {
         // Must currently have a pending atom to allow resynchronizing to it.
-        let _ = self.pending.as_ref().ok_or(AtomError::NoPendingAtom)?;
+        if !self.reader.is_seekable() {
+            let _ = self.pending.as_ref().ok_or(AtomError::NoPendingAtom)?;
+        }
 
         // Seek to the desired position. Doesn't seek if already in position.
         self.seek_reader(pos)?;


### PR DESCRIPTION
Currently, if we seek a m4a decoder after reaching eof, the pending atom is none, and the `next_packet` will fail. Relax the check for seekable stream, so the `seek_reader` will properly handle this case later.