### PR TITLE
aac: bound section index in decode_section_data to avoid panic

### DIFF
--- a/symphonia-codec-aac/src/aac/ics/mod.rs
+++ b/symphonia-codec-aac/src/aac/ics/mod.rs
@@ -240,6 +240,11 @@ impl Ics {
             let mut l = 0;
 
             while k < self.info.max_sfb {
+                // `l` counts sections, not bands, and advances once per section. A crafted
+                // stream with many zero-length sections can push it past the section arrays
+                // even though `k` (the band index) stays below `max_sfb`, so bound it here.
+                validate!(l < MAX_SFBS);
+
                 self.sect_cb[g][l] = bs.read_bits_leq32(4)? as u8;
                 self.sect_len[g][l] = 0;
 
@@ -602,4 +607,30 @@ fn read_escape<B: ReadBitsLtr>(bs: &mut B) -> Result<u16> {
     let word = (1 << (n + 4)) + bs.read_bits_leq32(n + 4)? as u16;
 
     Ok(word)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symphonia_core::io::BitReaderLtr;
+
+    #[test]
+    fn decode_section_data_rejects_excess_zero_length_sections() {
+        // For a long window each section is a 4-bit codebook followed by 5-bit
+        // length increments. An all-zero bitstream therefore reads codebook 0
+        // and a zero-length section every time, so the band index never reaches
+        // `max_sfb` while the section index keeps climbing. More than MAX_SFBS
+        // such sections used to run off the end of `sect_cb`; parsing must now
+        // fail cleanly instead of panicking. (MAX_SFBS + 1) sections at 9 bits
+        // each fit comfortably in this buffer.
+        let buf = [0u8; (MAX_SFBS + 1) * 9 / 8 + 1];
+
+        let mut ics = Ics::new(GASubbandInfo::find(44100));
+        ics.info.long_win = true;
+        ics.info.window_groups = 1;
+        ics.info.max_sfb = 1;
+
+        let mut bs = BitReaderLtr::new(&buf);
+        assert!(ics.decode_section_data(&mut bs).is_err());
+    }
 }


### PR DESCRIPTION
In `Ics::decode_section_data` the loop runs while the band index `k` is below `max_sfb`, but the section index `l` advances once per section and is never bounded by `MAX_SFBS`. A crafted AAC stream with many zero-length sections keeps `k` fixed while `l` climbs, so `sect_cb[g][l]` / `sect_len[g][l]` index one past the fixed-size arrays and panic:

```
thread 'main' panicked at symphonia-codec-aac/src/aac/ics/mod.rs:246:17:
index out of bounds: the len is 64 but the index is 64
```

This adds a `validate!(l < MAX_SFBS)` guard at the top of the loop so a malformed stream returns a decode error instead of panicking, matching how the surrounding code already rejects invalid input. Added a regression test that reproduces the out-of-bounds access.

Fixes #512