### PR TITLE
feat: add TimeBase duration conversion helpers

### DIFF
--- a/docs/guides/migration/0p6.md
+++ b/docs/guides/migration/0p6.md
@@ -31,7 +31,15 @@ In addition to the aforementioned restructuring, metadata and audio primitives h
 ### Track
 
 * Timing information that was previously stored in `CodecParameters` (`time_base`, `n_frames`, `start_ts`, `padding`, `delay`) are now stored directly in `Track`.
-* `Track` adds a new timing field: `duration`. While number of frames could also be considered a duration in time-base units, this is incorrect and only valid when the time-base is `1 / sample_rate`. While this is typical for types of audio files, it is not always the case, particularly for MKV files. The number of frames should be considered a unit-less count of decoded frames. For human readable duration, `duration` should be used instead.
+* `Track` adds a new timing field: `duration`. While number of frames could also be considered a duration in time-base units, this is incorrect and only valid when the time-base is `1 / sample_rate`. While this is typical for types of audio files, it is not always the case, particularly for MKV files. The number of frames should be considered a unit-less count of decoded frames. For human readable duration, `duration` should be used instead. Convert it with `TimeBase::calc_duration`; the checked conversion returns `None` if the result cannot be represented by `Time`, so applications must handle that case:
+  ```rust
+  if let (Some(time_base), Some(duration)) = (track.time_base, track.duration) {
+      match time_base.calc_duration(duration) {
+          Some(time) => display_duration(time),
+          None => display_unrepresentable_duration(),
+      }
+  }
+  ```
 * The duration and number of frames excludes any frames, and their cumulative duration, that will be discarded by a decoder if gapless playback is enabled.
 * `Track::codec_params` is now optional. It may be `None` if the track is of an unknown type.
 

--- a/symphonia-core/src/formats/mod.rs
+++ b/symphonia-core/src/formats/mod.rs
@@ -262,7 +262,8 @@ pub struct Track {
     /// The duration of the track in timebase units.
     ///
     /// If a timebase is available, this field can be used to calculate the total duration of the
-    /// track in seconds by using [`TimeBase::calc_time`] and passing the duration as the argument.
+    /// track in seconds by using [`TimeBase::calc_duration`]. The conversion returns `None` if the
+    /// result cannot be represented by [`Time`], which callers must handle.
     pub duration: Option<Duration>,
     /// The timestamp of the first frame.
     pub start_ts: Timestamp,
@@ -420,7 +421,8 @@ pub struct MediaInfo {
     /// The duration of the media in timebase units.
     ///
     /// If a timebase is available, this field can be used to calculate the total duration of the
-    /// media in seconds by using [`TimeBase::calc_time`] and passing the duration as the argument.
+    /// media in seconds by using [`TimeBase::calc_duration`]. The conversion returns `None` if the
+    /// result cannot be represented by [`Time`], which callers must handle.
     ///
     /// # For Implementations
     ///
@@ -489,10 +491,7 @@ impl MediaInfo {
                         // Calculate the duration of the track in seconds. Saturate here because if
                         // the track is too long then skipping this track to pick a shorter one that
                         // does not saturate is more wrong.
-                        let dur_as_ts =
-                            dur.timestamp_from(Timestamp::ZERO).unwrap_or(Timestamp::MAX);
-
-                        let dur_time = tb.calc_time_saturating(dur_as_ts);
+                        let dur_time = tb.calc_duration_saturating(dur);
 
                         Some((dur_time, t))
                     })
@@ -528,6 +527,38 @@ impl MediaInfo {
     pub fn with_start_ts(&mut self, start_ts: Timestamp) -> &mut Self {
         self.start_ts = start_ts;
         self
+    }
+}
+
+#[cfg(test)]
+mod media_info_tests {
+    use super::{MediaInfo, Track};
+    use crate::units::{Duration, TimeBase};
+
+    #[test]
+    fn verify_from_tracks_selects_longest_duration() {
+        let mut narrowed_longest = Track::new(0);
+        narrowed_longest
+            .with_time_base(TimeBase::try_new(1, u32::MAX).unwrap())
+            .with_duration(Duration::MAX);
+
+        let mut shorter = Track::new(1);
+        shorter
+            .with_time_base(TimeBase::try_new(1, 1).unwrap())
+            .with_duration(Duration::new(3_000_000_000));
+
+        let media_info = MediaInfo::from_tracks(&[narrowed_longest.clone(), shorter.clone()]);
+        assert_eq!(media_info.time_base, narrowed_longest.time_base);
+        assert_eq!(media_info.duration, narrowed_longest.duration);
+
+        let mut saturating_longest = Track::new(2);
+        saturating_longest
+            .with_time_base(TimeBase::try_new(u32::MAX, 1).unwrap())
+            .with_duration(Duration::MAX);
+
+        let media_info = MediaInfo::from_tracks(&[shorter, saturating_longest.clone()]);
+        assert_eq!(media_info.time_base, saturating_longest.time_base);
+        assert_eq!(media_info.duration, saturating_longest.duration);
     }
 }
 

--- a/symphonia-core/src/units.rs
+++ b/symphonia-core/src/units.rs
@@ -998,6 +998,34 @@ impl TimeBase {
         self.calc_time(ts).unwrap_or_else(|| if ts.is_negative() { Time::MIN } else { Time::MAX })
     }
 
+    /// Calculate a `Time` upto nanosecond precision from the provided `Duration` using `self` as
+    /// the conversion factor. Returns `None` if an overflow occurs.
+    pub fn calc_duration(&self, dur: Duration) -> Option<Time> {
+        const NS_PER_SEC_64: u64 = 1_000_000_000;
+        const NS_PER_SEC_128: u128 = 1_000_000_000;
+
+        let numer = u64::from(self.numer.get());
+        let denom = u64::from(self.denom.get());
+
+        if let Some(product) =
+            dur.get().checked_mul(numer).and_then(|x| x.checked_mul(NS_PER_SEC_64))
+        {
+            let total_nanos = product / denom;
+            Some(Time::from_nanos_u64(total_nanos))
+        }
+        else {
+            let product = u128::from(dur.get()) * u128::from(numer) * NS_PER_SEC_128;
+            let total_nanos = product / u128::from(denom);
+            Time::try_from_nanos_u128(total_nanos)
+        }
+    }
+
+    /// Calculate a `Time` upto nanosecond precision from the provided `Duration` using `self` as
+    /// the conversion factor. Saturates at [`Time::MAX`] if an overflow occurs.
+    pub fn calc_duration_saturating(&self, dur: Duration) -> Time {
+        self.calc_duration(dur).unwrap_or(Time::MAX)
+    }
+
     /// Calculate a `TimeStamp` from the provided `Time` using `self` as the conversion factor.
     /// Returns `None` if an overflow occurs.
     pub fn calc_timestamp(&self, time: Time) -> Option<Timestamp> {
@@ -1092,7 +1120,7 @@ impl fmt::Display for TimeBase {
 mod tests {
     use std::i64;
 
-    use super::{Time, TimeBase, Timestamp};
+    use super::{Duration, Time, TimeBase, Timestamp};
 
     #[test]
     fn verify_time() {
@@ -1328,6 +1356,29 @@ mod tests {
 
         assert!(tb4.calc_timestamp(Time::MIN).is_none());
         assert!(tb4.calc_timestamp(Time::MAX).is_none());
+    }
+
+    #[test]
+    fn verify_timebase_duration() {
+        let tb1 = TimeBase::try_new(1, 320).unwrap(); // 1 tick = 3.125 ms
+        let tb2 = TimeBase::try_new(1_000_000, 320_000_000).unwrap(); // 1 tick = 3.125 ms
+
+        for tb in [tb1, tb2] {
+            assert_eq!(tb.calc_duration(Duration::ZERO), Some(Time::ZERO));
+            assert_eq!(tb.calc_duration(Duration::new(12345)), tb.calc_time(Timestamp::new(12345)));
+        }
+
+        // Durations greater than i64::MAX can still be converted without narrowing through a
+        // Timestamp when the timebase is sufficiently small.
+        let small_tb = TimeBase::try_new(1, u32::MAX).unwrap();
+        let expected_seconds = 2_147_483_649u32;
+        let large_duration = Duration::new(u64::from(u32::MAX) * u64::from(expected_seconds));
+        assert_eq!(small_tb.calc_duration(large_duration), Some(Time::from(expected_seconds)));
+
+        // Test overflow and saturation.
+        let large_tb = TimeBase::try_new(u32::MAX, 1).unwrap();
+        assert!(large_tb.calc_duration(Duration::MAX).is_none());
+        assert_eq!(large_tb.calc_duration_saturating(Duration::MAX), Time::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Add checked and saturating `TimeBase` duration-conversion helpers in `symphonia-core/src/units.rs`, mirroring the existing `calc_time`/`calc_time_saturating` behavior while accepting the full unsigned `Duration` domain without requiring callers to narrow through `Timestamp`. Symphonia 0.6 separates the unsigned `Duration` type from the signed `Timestamp` type, but `TimeBase::calc_time` only accepts timestamps.

Convert zero and a representative fractional duration with both equivalent reduced and unreduced timebases, and verify the resulting `Time` matches the existing timestamp conversion for values shared by both domains; Convert a `Duration` greater than `i64::MAX` with a sufficiently small timebase and verify the checked helper succeeds without narrowing through `Timestamp`.

Fixes #530

AI was used for assistance.
