### PR TITLE
play: Fix panic when seeking to a timestamp

### DIFF
--- a/symphonia-play/src/main.rs
+++ b/symphonia-play/src/main.rs
@@ -225,7 +225,8 @@ fn run(args: &ArgMatches) -> Result<i32> {
                         .map(SeekPosition::Time)
                 }
                 else {
-                    args.get_one::<Timestamp>("seek-ts").map(|&ts| SeekPosition::Timestamp(ts))
+                    args.get_one::<i64>("seek-ts")
+                        .map(|&ts| SeekPosition::Timestamp(Timestamp::from(ts)))
                 };
 
                 // Setup playback options.


### PR DESCRIPTION
The seek-ts argument is registered with an i64 value parser, but the parsed value was retrieved as a Timestamp. Clap panics when the type requested from get_one does not match the type it stored, so every use of seek-ts aborted before seeking.

Retrieve the value as an i64 and convert it to a Timestamp.

Since this is in the play logic, I elected to not add test coverage due to the significant refactoring required to do so effectively.

Chugging along on #501